### PR TITLE
chore: gitignore secrets + local pytest/agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,16 @@ venv/
 *.egg-info/
 .pytest_cache/
 .ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
 
 # Environment
 .env
 .env.client
+# The appliance's runtime env files live next to their .example templates —
+# never commit the real ones; they carry R2 / camera creds.
+client-appliance/*.env
 
 # OS
 .DS_Store
@@ -35,3 +41,7 @@ Thumbs.db
 .idea/
 .vscode/
 *.swp
+
+# Agent / IDE-assistant local context — varies per developer, do not share
+.codex/
+AGENTS.md


### PR DESCRIPTION
## Summary

Four untracked files surfaced on the cameraboy test box that would have been staged by an accidental `git add .` / `git add -A`:

| File | Why it matters |
|---|---|
| `client-appliance/cameras.env` | 🔴 contains RTSP user/pass for the camera LAN |
| `.codex/` | Codex IDE local cache (per-dev) |
| `.coverage`, `.coverage.*` | pytest coverage artifacts |
| `AGENTS.md` | per-developer agent context |

The existing `.gitignore` ignored top-level `.env` and `.env.client` but **not** `client-appliance/*.env`. The matching `.example` templates next to the real env files stay tracked because they don't end in `.env`.

## Trade-offs

- **`AGENTS.md` ignored as per-dev**: I'm assuming this is local agent context that varies per developer (mine carries my own preferences). If the project later wants a shared `AGENTS.md`, a one-time `git add -f AGENTS.md` overrides the ignore. Flag if I'm wrong about the intent.
- **Narrow `client-appliance/*.env` over global `*.env`**: keeps the door open for `.env` files elsewhere in the tree (e.g. test fixtures) without retroactively ignoring them. Targeted at the known credential-bearing location.

## Test plan

- [x] `git check-ignore -v` shows all four files now matched.
- [x] `client-appliance/cameras.env.example` (the template) is **NOT** matched — `.example` suffix preserves it as a tracked template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)