### PR TITLE
ci(docker): disable provenance + sbom on gpu-service push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,18 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Disable provenance + SBOM attestations: every main-branch push of
+          # this image (the 15 GB gpu-service one) since 2026-06-10 #43 has
+          # been failing the *push* step against GHCR with
+          # `ERROR: failed to build: unknown blob`. The pattern matches a
+          # known buildx + GHCR interaction where attestation manifests
+          # reference blobs by digest that GHCR has not yet committed when
+          # the attestation tries to land. Disabling provenance is the
+          # documented fix in the docker/build-push-action issue tracker.
+          # PR-event builds (push=false) were unaffected because they never
+          # reached the push step.
+          provenance: false
+          sbom: false
 
   client-agent:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Unblocks `:latest` image publish on main. Every main-branch push of the 15 GB gpu-service image since #43 merged this morning has failed at the push step:

```
ERROR: failed to build: unknown blob
```

Two consecutive reruns (one at merge time, one manual) produced the identical error — not a GHCR transient. Successful builds: `2e2ec65` and earlier (last green at 08:04 UTC). Every commit since (#43, #44, #45) failed at the same point.

## Root cause

`docker/build-push-action@v6` emits **attestation manifests** (provenance + SBOM) by default. Those manifests reference the just-pushed layer blobs by digest. On the gpu-service image specifically — likely because of its size (15 GB, several multi-GB layers) and longer push time — the attestation manifest tries to commit before GHCR has finalized the blob commits, producing `unknown blob`.

This is documented in [docker/build-push-action#issues mentioning "unknown blob"](https://github.com/docker/build-push-action/issues?q=unknown+blob) and the standard fix is to disable provenance + SBOM attestations on the affected image.

## What changed

- gpu-service step gets `provenance: false` + `sbom: false`
- client-agent step left unchanged (smaller image, no issue)

## Test plan

- [ ] Workflow run on this PR builds gpu-service cleanly (PR events have `push=false` so we won't actually see the push step exercised; that's the load-bearing test on merge)
- [ ] After merge, the main-branch workflow rebuilds `:latest` cleanly with #43 VRAM pre-flight + #44 / #45 client-agent code baked in
- [ ] `docker manifest inspect ghcr.io/kopalniekrypto/cctv-gpu-engine/gpu-service:latest` shows a newer digest than `2e2ec65`

## Why disabling attestations is acceptable

Provenance and SBOM are nice-to-haves for supply-chain audit. We're not currently consuming them in our deploy pipeline (no `cosign verify` step before `docker pull` on cctv-vps / cctv-vps-2). When we add SLSA-level attestation requirements later, we can re-enable with a different push strategy (e.g. separate-manifest push) but for now the working baseline matters more than the missing attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)