### PR TITLE
ci(docker): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
       - "pipeline/**"
       - "gpu-service/**"
       - "client-agent/**"
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` to `docker.yml` so the build can be triggered manually.

## Why

`docker.yml` is path-filtered to `pipeline/`, `gpu-service/`, and `client-agent/`. Infra-only changes — like #47 (which fixed the `unknown blob` push failure by disabling provenance + SBOM) — never trigger the workflow, so the fix can't be exercised until an unrelated code change happens to touch one of the watched paths. With `workflow_dispatch:` we can manually validate CI fixes on-demand from the Actions UI or:

\`\`\`
gh workflow run docker.yml --ref main
\`\`\`

## Test plan

- [ ] Workflow file parses (no Actions syntax errors on the PR's own validation)
- [ ] After merge, "Run workflow" button appears on the Actions page for "Build Docker images"
- [ ] Manual dispatch on main builds + pushes gpu-service cleanly (this is the load-bearing test for #47's fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)