### PR TITLE
fix(recorder): Recorder.stop() actually terminates ffmpeg (#52)

### DIFF
--- a/client-agent/client_agent/appliance_test.py
+++ b/client-agent/client_agent/appliance_test.py
@@ -13,6 +13,8 @@ should not break these tests.
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -634,6 +636,144 @@ def test_run_platform_session_stops_recorder_when_camera_flips_to_disabled() -> 
     assert active_recorders == {}
     # No new spawn — disabled means tear-down only.
     assert factory_calls == 0
+
+
+class _InFlightFakePopen:
+    """``subprocess.Popen``-shaped fake whose ``communicate`` blocks until the
+    recorder terminates it — models an ffmpeg that keeps capturing until it is
+    signalled. Records ``terminated`` so a test can prove reconcile actually
+    SIGTERMed the child (issue #52) rather than merely dropping the handle.
+
+    Deliberately kept self-contained (not imported from ``recorder_test``) so
+    each test module owns its fakes, matching this file's ``_make_camera``
+    style."""
+
+    def __init__(self, cmd) -> None:  # noqa: ANN001
+        self.args = cmd
+        self.cmd = cmd
+        self.terminated = False
+        self.killed = False
+        self.returncode: int | None = None
+        self._exited = threading.Event()
+        self.entered_wait = threading.Event()
+
+    def poll(self):  # noqa: ANN201
+        return self.returncode
+
+    def wait(self, timeout=None):  # noqa: ANN001, ANN201
+        self.entered_wait.set()
+        if not self._exited.wait(timeout):
+            import subprocess
+
+            raise subprocess.TimeoutExpired(self.cmd, timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def communicate(self, timeout=None):  # noqa: ANN001, ANN201
+        self.wait(timeout)
+        return ("", "")
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._exited.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._exited.set()
+
+
+def test_run_platform_session_disable_terminates_underlying_ffmpeg(tmp_path: Path) -> None:
+    """Issue #52 acceptance: revoking a camera must terminate its ffmpeg child,
+    not just drop the handle from the active map. Before the fix, reconcile's
+    ``stop`` only flipped in-memory state — ffmpeg kept writing chunks for up
+    to ``duration_s`` (default 1h) after the operator disabled the camera.
+
+    Unlike the MagicMock disable test above, this wires a *real*
+    ``BackgroundRecorder(Recorder(...))`` to a fake ffmpeg, so it proves the
+    whole disable path (heartbeat → reconcile → ``_stop`` → ``BackgroundRecorder.stop``
+    → ``Recorder.stop`` → ``terminate``) reaches the process, not just the map."""
+    import httpx
+    import respx
+
+    from client_agent.appliance import run_platform_session
+    from client_agent.platform import PlatformClient
+    from client_agent.recorder import BackgroundRecorder, Recorder
+
+    created: list[_InFlightFakePopen] = []
+
+    def _popen_factory(cmd, **kwargs):  # noqa: ANN001, ANN202
+        proc = _InFlightFakePopen(cmd)
+        created.append(proc)
+        return proc
+
+    def recorder_factory():  # noqa: ANN202
+        return BackgroundRecorder(
+            Recorder(
+                uploader=None,  # buffer mode never uploads
+                popen_factory=_popen_factory,
+                output_dir_factory=lambda cam_id: str(tmp_path / "buffer" / cam_id),
+            )
+        )
+
+    active: dict[str, object] = {}
+    discover_fn = lambda: [_make_camera()]  # noqa: E731
+
+    enabled = {
+        "cameras": [
+            {
+                "id": "cam-1",
+                "enabled": True,
+                "rtsp_url": "rtsp://192.168.50.2:554/live",
+                "duration_s": 86400,
+            }
+        ]
+    }
+    disabled = {
+        "cameras": [{"id": "cam-1", "enabled": False, "rtsp_url": "rtsp://192.168.50.2:554/live"}]
+    }
+    heartbeat_calls = {"n": 0}
+
+    def _heartbeat(request):  # noqa: ANN001, ANN202
+        cfg = enabled if heartbeat_calls["n"] == 0 else disabled
+        heartbeat_calls["n"] += 1
+        return httpx.Response(200, json={"config": cfg})
+
+    with respx.mock(base_url="https://platform.example") as mock:
+        mock.post("/appliance/register").mock(
+            return_value=httpx.Response(200, json={"appliance_id": "a", "tenant_id": "t"})
+        )
+        mock.post("/appliance/cameras").mock(return_value=httpx.Response(204))
+        mock.post("/appliance/heartbeat").mock(side_effect=_heartbeat)
+        client = PlatformClient(base_url="https://platform.example", token="tok")
+
+        # Heartbeat 1: cam-1 enabled → spawn a buffer-mode recorder.
+        run_platform_session(
+            platform_client=client,
+            discover_fn=discover_fn,
+            recorder_factory=recorder_factory,
+            active_recorders=active,
+            environ={},
+        )
+
+        # Wait until ffmpeg is spawned and actually capturing.
+        deadline = time.time() + 2.0
+        while not (created and created[0].entered_wait.is_set()) and time.time() < deadline:
+            time.sleep(0.01)
+        assert created and created[0].entered_wait.is_set(), "recorder never started ffmpeg"
+        assert "cam-1" in active
+
+        # Heartbeat 2: operator revoked approval → reconcile must stop it.
+        run_platform_session(
+            platform_client=client,
+            discover_fn=discover_fn,
+            recorder_factory=recorder_factory,
+            active_recorders=active,
+            environ={},
+        )
+
+    assert created[0].terminated is True, "reconcile disable must terminate the ffmpeg child"
+    assert active == {}, "the disabled camera's handle must be dropped from the active map"
 
 
 # ----- 6. reconcile_recorders: camera approval lock (issue #27, Slice 1c.2) -----

--- a/client-agent/client_agent/recorder.py
+++ b/client-agent/client_agent/recorder.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import subprocess
 import threading
 import uuid
 from collections.abc import Callable
@@ -52,8 +53,6 @@ def probe_rtsp(url: str, *, timeout: float, runner) -> ProbeResult:
     hung past the deadline" — we catch it here so the operator sees a
     clean ProbeResult instead of a Flask 500 (#8 testing focus).
     """
-    import subprocess as _sp
-
     try:
         result = runner(
             [
@@ -72,7 +71,7 @@ def probe_rtsp(url: str, *, timeout: float, runner) -> ProbeResult:
             capture_output=True,
             text=True,
         )
-    except _sp.TimeoutExpired:
+    except subprocess.TimeoutExpired:
         return ProbeResult(ok=False, message=f"timeout after {timeout}s")
     if result.returncode == 0:
         return ProbeResult(ok=True)
@@ -210,13 +209,33 @@ class Recorder:
     one-shot recordings (Flask UI flow) still require an uploader."""
 
     uploader: _UploaderLike | None = None
-    runner: Callable[..., Any]
+    # ``runner`` is the ``subprocess.run``-shaped boundary used ONLY by
+    # :meth:`probe` (a bounded, blocking call that must surface
+    # ``TimeoutExpired``). ``popen_factory`` is the ``subprocess.Popen``-shaped
+    # boundary used by the recording itself: we keep the handle so
+    # :meth:`stop` can actually SIGTERM the ffmpeg child (issue #52) instead
+    # of only flipping in-memory state.
+    runner: Callable[..., Any] = subprocess.run
+    popen_factory: Callable[..., Any] = subprocess.Popen
     output_dir_factory: Callable[[str], str]
     job_id_factory: Callable[[], str] = _default_job_id
     clock: Callable[[], datetime] = field(default=lambda: datetime.now(UTC))
+    # Seconds to wait for ffmpeg to honour SIGTERM before escalating to
+    # SIGKILL (issue #52). ffmpeg flushes the current segment's moov atom on
+    # SIGTERM, so a few seconds keeps the last chunk playable; past that we
+    # stop waiting so an operator "stop" can't hang on a wedged encoder.
+    stop_grace_s: float = 5.0
 
     _status: RecorderStatus = field(default_factory=RecorderStatus)
     _lock: threading.Lock = field(default_factory=threading.Lock)
+    # Handle on the in-flight ffmpeg child (``None`` when idle). Held under
+    # ``_lock`` so :meth:`stop` on the web thread can read it while the
+    # recording thread is blocked in ``communicate()``.
+    _proc: Any = field(default=None)
+    # Set by :meth:`stop` so the recording thread, once ffmpeg is terminated
+    # and ``communicate`` returns, knows the exit was operator-requested and
+    # skips the R2 upload (a killed recording must not create a phantom job).
+    _cancelled: bool = field(default=False)
 
     def status(self) -> RecorderStatus:
         """Return a snapshot of the current state. Cheap, lock-protected."""
@@ -241,7 +260,23 @@ class Recorder:
         is the source of truth in this mode.
 
         Default (``camera_id=None``) is the legacy one-shot mode: chunks
-        upload to R2 immediately and the temp dir is removed afterwards."""
+        upload to R2 immediately and the temp dir is removed afterwards.
+
+        Split into :meth:`_reserve` (atomic slot claim) + :meth:`_run`
+        (the ffmpeg work) so :class:`BackgroundRecorder` can claim the slot
+        synchronously on the HTTP thread and only defer ``_run`` to the
+        daemon thread — closing the concurrent-start TOCTOU (issue #52)."""
+        job_id = self._reserve(camera_id)
+        return self._run(job_id, url=url, duration_s=duration_s, camera_id=camera_id)
+
+    def _reserve(self, camera_id: str | None) -> str:
+        """Atomically claim the single recording slot, returning the ``job_id``.
+
+        Raises :class:`RecorderBusy` if a recording is already in flight. This
+        is the ONLY place the ``idle → recording`` transition happens, and it
+        runs under ``_lock``, so two callers racing to start can never both
+        win — exactly one gets the slot, the other gets ``RecorderBusy`` on
+        its own (HTTP) thread."""
         buffer_mode = camera_id is not None
         with self._lock:
             if self._status.state in ("recording", "uploading"):
@@ -251,17 +286,53 @@ class Recorder:
             # way (one identifier per active recording).
             job_id = camera_id if buffer_mode else self.job_id_factory()
             self._status = RecorderStatus(state="recording", job_id=job_id)
+            self._cancelled = False
+            self._proc = None
+        return job_id
 
+    def _run(self, job_id: str, *, url: str, duration_s: int, camera_id: str | None) -> str:
+        """Run ffmpeg for an already-reserved slot and upload/keep its chunks.
+
+        Assumes :meth:`_reserve` has already claimed the slot for ``job_id``;
+        never re-checks busy state. Safe to run on a background thread."""
+        buffer_mode = camera_id is not None
         out_dir = Path(self.output_dir_factory(job_id))
         out_dir.mkdir(parents=True, exist_ok=True)
         cmd = build_ffmpeg_cmd(
             url=url, duration_s=duration_s, output_dir=str(out_dir), buffer_mode=buffer_mode
         )
+        # Spawn ffmpeg and KEEP THE HANDLE so ``stop`` can terminate it
+        # (issue #52). ``communicate`` blocks until ffmpeg exits — naturally
+        # (``-t`` elapsed), on a crash, or because ``stop`` sent it a signal.
         # We don't catch subprocess errors here — partial output (the
         # camera-offline-mid-recording case) is reported by ffmpeg as a
         # non-zero exit but still leaves chunks on disk, so we always
         # walk the dir afterwards instead of branching on returncode.
-        result = self.runner(cmd, capture_output=True, text=True)
+        proc = self.popen_factory(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        with self._lock:
+            self._proc = proc
+            # Close the spawn-window race: if ``stop`` fired between the
+            # reservation and here (proc was still ``None`` when it looked),
+            # it set ``_cancelled`` without a handle to kill. Honour it now so
+            # a stop-right-after-start can never leave ffmpeg running.
+            cancel_now = self._cancelled
+        if cancel_now:
+            self._terminate_proc(proc)
+        _, stderr = proc.communicate()
+        returncode = proc.returncode
+        with self._lock:
+            self._proc = None
+            cancelled = self._cancelled
+
+        if cancelled:
+            # Operator/platform requested the stop. Do NOT upload a killed
+            # legacy recording (issue point #2 — that phantom job would just
+            # fail in the GPU worker); buffer-mode chunks stay on disk for the
+            # poller. ``stop`` already set state=idle; leave it (a fresh start
+            # may already own the state machine, so we must not clobber it).
+            if not buffer_mode:
+                shutil.rmtree(out_dir, ignore_errors=True)
+            return job_id
 
         chunks = sorted(out_dir.glob("*.mp4"))
         # Filter out 0-byte files — ffmpeg creates the output file before
@@ -274,8 +345,7 @@ class Recorder:
                 self._status = RecorderStatus(
                     state="failed",
                     job_id=job_id,
-                    message=(getattr(result, "stderr", "") or "").strip()
-                    or f"ffmpeg exited {getattr(result, 'returncode', '?')} with no output",
+                    message=(stderr or "").strip() or f"ffmpeg exited {returncode} with no output",
                 )
             if not buffer_mode:
                 shutil.rmtree(out_dir, ignore_errors=True)
@@ -335,16 +405,37 @@ class Recorder:
         return probe_rtsp(url, timeout=timeout, runner=self.runner)
 
     def stop(self) -> None:
-        """Mark the current recording as cancelled.
+        """Terminate the in-flight ffmpeg child and reset to ``idle`` (issue #52).
 
-        The synchronous ffmpeg run can't be interrupted from here without
-        a real subprocess handle, but flipping state to ``idle`` lets the
-        web layer return a clean 200 and the next recording proceed. The
-        production wiring (web route → background thread → real
-        ``subprocess.run``) hands the actual SIGTERM problem to the
-        thread layer, which is out of scope for the unit tests."""
+        For a CCTV product "stop recording" must mean recording stops *now*,
+        not "within ``duration_s``". We hold the ffmpeg handle (``_proc``), so
+        this actually SIGTERMs it: the recording thread's ``communicate``
+        returns, sees ``_cancelled``, and skips the upload.
+
+        Ordering is race-safe against a near-simultaneous ``start``: we set
+        ``_cancelled`` and read ``_proc`` under the same lock ``start`` uses to
+        publish the handle. If the handle isn't up yet (stop beat the spawn),
+        ``start`` observes ``_cancelled`` right after it publishes ``_proc``
+        and terminates the child itself.
+
+        Idempotent: calling ``stop`` while idle just re-asserts idle."""
         with self._lock:
+            self._cancelled = True
+            proc = self._proc
             self._status = RecorderStatus(state="idle")
+        if proc is not None:
+            self._terminate_proc(proc)
+
+    def _terminate_proc(self, proc: Any) -> None:
+        """SIGTERM the ffmpeg child and wait up to ``stop_grace_s`` for it to
+        flush and exit. Safe to call from the web thread while the recording
+        thread is blocked in ``communicate`` — modern CPython guards
+        concurrent ``wait``/``communicate`` on one ``Popen`` internally."""
+        proc.terminate()
+        try:
+            proc.wait(timeout=self.stop_grace_s)
+        except subprocess.TimeoutExpired:
+            proc.kill()
 
 
 class BackgroundRecorder:
@@ -367,25 +458,28 @@ class BackgroundRecorder:
         self._thread: threading.Thread | None = None
 
     def start(self, *, url: str, duration_s: int, camera_id: str | None = None) -> str:
-        # Pre-flight the busy check on the main thread so /start can
-        # return 409 *before* the operator's request returns. Otherwise
-        # the rejection would be invisible to the HTTP layer.
-        snapshot = self._inner.status()
-        if snapshot.state in ("recording", "uploading"):
-            raise RecorderBusy(f"recorder already busy in state {snapshot.state!r}")
+        # Claim the recording slot SYNCHRONOUSLY on the caller's (HTTP)
+        # thread. ``_reserve`` does the atomic idle→recording flip under the
+        # inner lock and raises ``RecorderBusy`` if the slot is taken — so a
+        # second concurrent ``/start`` is rejected here, on the request
+        # thread, and the web layer turns it into a 409. The old code only
+        # pre-checked a stale ``status()`` then spawned the thread, so two
+        # near-simultaneous callers both passed and the loser raised
+        # ``RecorderBusy`` invisibly inside its daemon thread (issue #52 #4).
+        job_id = self._inner._reserve(camera_id)
 
         def _target() -> None:
-            # Wrap the synchronous Recorder.start so an exception inside
-            # ffmpeg / upload / status-handshake does NOT silently kill the
-            # daemon thread with no trace. Source incident: Wi-Fi blip on a
-            # macOS dev box dropped the RTSP TCP, ffmpeg exited with an
-            # error, the exception propagated out of the thread and
-            # ``reconcile_recorders`` then refused to respawn because the
-            # dead handle was still in ``active`` (#66-shaped silent fail
-            # for the recorder lane). The warning + downstream is_running()
-            # check together make this self-healing on the next heartbeat.
+            # Wrap ``_run`` so an exception inside ffmpeg / upload /
+            # status-handshake does NOT silently kill the daemon thread with
+            # no trace. Source incident: Wi-Fi blip on a macOS dev box dropped
+            # the RTSP TCP, ffmpeg exited with an error, the exception
+            # propagated out of the thread and ``reconcile_recorders`` then
+            # refused to respawn because the dead handle was still in
+            # ``active`` (#66-shaped silent fail for the recorder lane). The
+            # warning + downstream is_running() check together make this
+            # self-healing on the next heartbeat.
             try:
-                self._inner.start(url=url, duration_s=duration_s, camera_id=camera_id)
+                self._inner._run(job_id, url=url, duration_s=duration_s, camera_id=camera_id)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "recorder thread for camera_id=%s url=%s exited with exception: %s",

--- a/client-agent/client_agent/recorder_test.py
+++ b/client-agent/client_agent/recorder_test.py
@@ -14,6 +14,7 @@ production code can pass ``subprocess.run`` directly with no shim.
 from __future__ import annotations
 
 import subprocess
+import threading
 from typing import Any
 
 from client_agent.recorder import (
@@ -196,29 +197,124 @@ class FakeR2ForRecorder:
         self.statuses[job_id] = status
 
 
-def _make_runner_that_writes_chunks(
-    chunks: dict[str, bytes],
-    returncode: int = 0,
-    stderr: str = "",
-):
-    """Build a runner that simulates ffmpeg by dropping files into the
-    recording dir before "exiting". The runner inspects the cmd to find
-    the output template (last positional) and resolves the dir from it,
-    then materialises the requested chunk files there. This is the
-    cleanest way to fake ffmpeg without conditionally branching on cmd
-    shape — both the short and long branches end up with files on disk."""
+class FakePopen:
+    """``subprocess.Popen``-shaped fake for the recorder's recording boundary.
 
-    def _run(cmd, **kwargs):  # noqa: ANN001
+    Issue #52 moved recording from a blocking ``subprocess.run`` to a
+    ``subprocess.Popen`` handle the recorder keeps so ``stop`` can SIGTERM
+    the ffmpeg child. This fake mirrors just the slice the recorder uses:
+    ``communicate`` / ``wait`` / ``poll`` / ``terminate`` / ``kill`` /
+    ``returncode``.
+
+    Two lifecycles:
+
+    * ``auto_exit=True`` (default) — ffmpeg "ran its course" (``-t`` elapsed)
+      and exited on its own: ``communicate``/``wait`` return immediately.
+      Used by the single-threaded happy-path tests.
+    * ``auto_exit=False`` — a long capture that only ends when the recorder
+      signals it: ``communicate``/``wait`` block on an Event that
+      ``terminate``/``kill`` set. Lets a ``stop`` test drive the in-flight
+      case from another thread.
+
+    Chunk files are materialised at construction (ffmpeg opens its output
+    while capturing), so both the upload path and the "partial chunks left
+    on disk" path see files regardless of how the process ends.
+
+    ``ignore_terminate=True`` models a wedged ffmpeg that shrugs off SIGTERM,
+    forcing ``stop`` to escalate to ``kill()`` after the grace window.
+    """
+
+    def __init__(
+        self,
+        cmd,  # noqa: ANN001
+        *,
+        chunks: dict[str, bytes] | None = None,
+        returncode: int = 0,
+        stderr: str = "",
+        auto_exit: bool = True,
+        ignore_terminate: bool = False,
+    ) -> None:
         from pathlib import Path
 
-        output_template = cmd[-1]
-        out_dir = Path(output_template).parent
-        out_dir.mkdir(parents=True, exist_ok=True)
-        for name, data in chunks.items():
-            (out_dir / name).write_bytes(data)
-        return subprocess.CompletedProcess(args=cmd, returncode=returncode, stderr=stderr)
+        self.args = cmd
+        self.cmd = cmd
+        self.terminated = False
+        self.killed = False
+        self.returncode: int | None = None
+        self._pending_returncode = returncode
+        self._stderr = stderr
+        self._ignore_terminate = ignore_terminate
+        self._exited = threading.Event()
+        self._reap_lock = threading.Lock()
+        # Set the instant the recorder starts blocking in ``wait``/``communicate``.
+        # Lets a stop-test synchronise on "ffmpeg is genuinely in flight" instead
+        # of racing the spawn window.
+        self.entered_wait = threading.Event()
+        if chunks:
+            out_dir = Path(cmd[-1]).parent
+            out_dir.mkdir(parents=True, exist_ok=True)
+            for name, data in chunks.items():
+                (out_dir / name).write_bytes(data)
+        if auto_exit:
+            self._exited.set()
 
-    return _run
+    def _reap(self) -> None:
+        with self._reap_lock:
+            if self.returncode is None:
+                self.returncode = self._pending_returncode
+
+    def poll(self):  # noqa: ANN201
+        return self.returncode
+
+    def wait(self, timeout=None):  # noqa: ANN001, ANN201
+        self.entered_wait.set()
+        if not self._exited.wait(timeout):
+            raise subprocess.TimeoutExpired(self.cmd, timeout)
+        self._reap()
+        return self.returncode
+
+    def communicate(self, timeout=None):  # noqa: ANN001, ANN201
+        self.wait(timeout)
+        return ("", self._stderr)
+
+    def terminate(self) -> None:
+        self.terminated = True
+        if not self._ignore_terminate:
+            self._exited.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._exited.set()
+
+
+def _popen_factory(
+    chunks: dict[str, bytes] | None = None,
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+    auto_exit: bool = True,
+    ignore_terminate: bool = False,
+):
+    """Build a ``subprocess.Popen``-shaped factory that yields :class:`FakePopen`.
+
+    Every spawned process is recorded on ``.created`` so a test can assert
+    on ``terminate``/``kill`` after the recording ends."""
+    created: list[FakePopen] = []
+
+    def _factory(cmd, **kwargs):  # noqa: ANN001, ANN202
+        proc = FakePopen(
+            cmd,
+            chunks=chunks,
+            returncode=returncode,
+            stderr=stderr,
+            auto_exit=auto_exit,
+            ignore_terminate=ignore_terminate,
+        )
+        created.append(proc)
+        return proc
+
+    _factory.created = created  # type: ignore[attr-defined]
+    return _factory
 
 
 # ----- 7. Recorder.start invokes runner with the right cmd and transitions state -----
@@ -233,15 +329,15 @@ def test_recorder_start_invokes_ffmpeg_and_uploads_chunks(tmp_path) -> None:  # 
     Uses an injected ``output_dir_factory`` so the test pins the temp dir
     under pytest's ``tmp_path`` instead of the real ``/tmp``."""
     fake_r2 = FakeR2ForRecorder()
-    runner_calls: list[list[str]] = []
+    popen_calls: list[list[str]] = []
 
-    def _capturing_runner(cmd, **kwargs):  # noqa: ANN001
-        runner_calls.append(list(cmd))
-        return _make_runner_that_writes_chunks({"recording.mp4": b"fake-mp4-bytes"})(cmd, **kwargs)
+    def _capturing_factory(cmd, **kwargs):  # noqa: ANN001
+        popen_calls.append(list(cmd))
+        return FakePopen(cmd, chunks={"recording.mp4": b"fake-mp4-bytes"})
 
     rec = Recorder(
         uploader=fake_r2,
-        runner=_capturing_runner,
+        popen_factory=_capturing_factory,
         output_dir_factory=lambda job_id: str(tmp_path / job_id),
         job_id_factory=lambda: "job-rec-001",
     )
@@ -249,9 +345,9 @@ def test_recorder_start_invokes_ffmpeg_and_uploads_chunks(tmp_path) -> None:  # 
     rec.start(url="rtsp://camera.local/stream", duration_s=3600)
 
     # ffmpeg was invoked once with the cmd build_ffmpeg_cmd would produce.
-    assert len(runner_calls) == 1
-    assert runner_calls[0][0] == "ffmpeg"
-    assert "rtsp://camera.local/stream" in runner_calls[0]
+    assert len(popen_calls) == 1
+    assert popen_calls[0][0] == "ffmpeg"
+    assert "rtsp://camera.local/stream" in popen_calls[0]
     # Chunk reached R2 with the right job_id and the bytes ffmpeg "wrote".
     assert fake_r2.uploaded == [("job-rec-001", b"fake-mp4-bytes")]
     # status.json handshake — pending so the worker picks it up.
@@ -273,25 +369,24 @@ def test_recorder_rejects_concurrent_start(tmp_path) -> None:  # noqa: ANN001
     both recordings."""
     fake_r2 = FakeR2ForRecorder()
 
-    # A runner that pauses the "ffmpeg" call long enough for the second
-    # start to race in. We do this by having the runner itself call back
-    # into the recorder before "exiting" — easier than wiring threads.
+    # A factory that observes state *while ffmpeg is spawning* by re-entering
+    # the recorder before returning the handle — easier than wiring threads.
+    # The outer start has already reserved state='recording' by the time the
+    # factory runs, so the second start must raise.
     busy_observed: list[bool] = []
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
-        # While we're "inside ffmpeg", state should be 'recording' and
-        # a second start must raise.
+    def _factory(cmd, **kwargs):  # noqa: ANN001
         try:
             rec.start(url="rtsp://other/stream", duration_s=3600)
             busy_observed.append(False)
         except RecorderBusy:
             busy_observed.append(True)
         # Then act like a normal successful ffmpeg run.
-        return _make_runner_that_writes_chunks({"recording.mp4": b"x"})(cmd, **kwargs)
+        return FakePopen(cmd, chunks={"recording.mp4": b"x"})
 
     rec = Recorder(
         uploader=fake_r2,
-        runner=_runner,
+        popen_factory=_factory,
         output_dir_factory=lambda job_id: str(tmp_path / job_id),
         job_id_factory=lambda: "job-busy-1",
     )
@@ -316,15 +411,10 @@ def test_recorder_marks_failed_when_ffmpeg_produces_no_chunks(tmp_path) -> None:
     and surface the error in the UI."""
     fake_r2 = FakeR2ForRecorder()
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
-        # Don't write any chunk files — simulate "ffmpeg refused the URL".
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=1, stderr="rtsp://nope: Connection refused"
-        )
-
     rec = Recorder(
         uploader=fake_r2,
-        runner=_runner,
+        # No chunk files — simulate "ffmpeg refused the URL".
+        popen_factory=_popen_factory(returncode=1, stderr="rtsp://nope: Connection refused"),
         output_dir_factory=lambda job_id: str(tmp_path / job_id),
         job_id_factory=lambda: "job-doomed",
     )
@@ -351,17 +441,14 @@ def test_recorder_rejects_zero_byte_chunks(tmp_path) -> None:  # noqa: ANN001
     no R2 writes."""
     fake_r2 = FakeR2ForRecorder()
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
+    rec = Recorder(
+        uploader=fake_r2,
         # Simulate ffmpeg creating an empty file and failing.
-        return _make_runner_that_writes_chunks(
+        popen_factory=_popen_factory(
             {"recording.mp4": b""},
             returncode=1,
             stderr="Could not find tag for codec pcm_mulaw in stream #1",
-        )(cmd, **kwargs)
-
-    rec = Recorder(
-        uploader=fake_r2,
-        runner=_runner,
+        ),
         output_dir_factory=lambda job_id: str(tmp_path / job_id),
         job_id_factory=lambda: "job-zerobyte",
     )
@@ -391,17 +478,14 @@ def test_recorder_uploads_partial_chunks_when_ffmpeg_fails_late(tmp_path) -> Non
     single status.json was written."""
     fake_r2 = FakeR2ForRecorder()
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
+    rec = Recorder(
+        uploader=fake_r2,
         # Simulate ffmpeg flushing two segments before crashing.
-        return _make_runner_that_writes_chunks(
+        popen_factory=_popen_factory(
             {"chunk_000.mp4": b"hour-1", "chunk_001.mp4": b"hour-2"},
             returncode=1,
             stderr="RTSP/1.0 200 OK ... Input/output error",
-        )(cmd, **kwargs)
-
-    rec = Recorder(
-        uploader=fake_r2,
-        runner=_runner,
+        ),
         output_dir_factory=lambda job_id: str(tmp_path / job_id),
         job_id_factory=lambda: "job-partial",
     )
@@ -427,12 +511,9 @@ def test_recorder_cleans_up_temp_dir_after_upload(tmp_path) -> None:  # noqa: AN
     fake_r2 = FakeR2ForRecorder()
     out_dir = tmp_path / "job-cleanup"
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
-        return _make_runner_that_writes_chunks({"recording.mp4": b"some bytes"})(cmd, **kwargs)
-
     rec = Recorder(
         uploader=fake_r2,
-        runner=_runner,
+        popen_factory=_popen_factory({"recording.mp4": b"some bytes"}),
         output_dir_factory=lambda job_id: str(out_dir),
         job_id_factory=lambda: "job-cleanup",
     )
@@ -453,14 +534,11 @@ def test_recorder_status_preserves_chunks_uploaded_after_idle(tmp_path) -> None:
     idle reset clobbered the counter."""
     fake_r2 = FakeR2ForRecorder()
 
-    def _runner(cmd, **kwargs):  # noqa: ANN001
-        return _make_runner_that_writes_chunks(
-            {"chunk_000.mp4": b"a", "chunk_001.mp4": b"b", "chunk_002.mp4": b"c"}
-        )(cmd, **kwargs)
-
     rec = Recorder(
         uploader=fake_r2,
-        runner=_runner,
+        popen_factory=_popen_factory(
+            {"chunk_000.mp4": b"a", "chunk_001.mp4": b"b", "chunk_002.mp4": b"c"}
+        ),
         output_dir_factory=lambda jid: str(tmp_path / jid),
         job_id_factory=lambda: "job-count",
     )
@@ -496,7 +574,7 @@ def test_recorder_buffer_mode_routes_to_camera_id_and_leaves_chunks(tmp_path) ->
 
     rec = Recorder(
         uploader=fake_r2,
-        runner=_make_runner_that_writes_chunks({"chunk_000.mp4": b"aaa", "chunk_001.mp4": b"bbb"}),
+        popen_factory=_popen_factory({"chunk_000.mp4": b"aaa", "chunk_001.mp4": b"bbb"}),
         output_dir_factory=_factory,
         # job_id_factory should NOT be called in buffer mode — wire it to a
         # sentinel that would explode if invoked.
@@ -539,7 +617,7 @@ def test_multichunk_recording_uploads_distinct_r2_keys(tmp_path) -> None:  # noq
 
     rec = Recorder(
         uploader=fake_r2,
-        runner=_make_runner_that_writes_chunks(
+        popen_factory=_popen_factory(
             {"chunk_000.mp4": b"h0", "chunk_001.mp4": b"h1", "chunk_002.mp4": b"h2"}
         ),
         output_dir_factory=lambda jid: str(tmp_path / jid),
@@ -555,6 +633,143 @@ def test_multichunk_recording_uploads_distinct_r2_keys(tmp_path) -> None:  # noq
     ]
     # Distinctness is the crux — the bug produced three identical keys.
     assert len(set(fake_r2.keys)) == 3
+
+
+# ===== stop() actually terminates the ffmpeg child (issue #52) =====
+#
+# Before #52, ``stop`` only flipped in-memory state to idle; the blocking
+# ``subprocess.run`` had no handle so ffmpeg kept capturing for up to
+# ``duration_s``. With the ``popen_factory`` boundary the recorder holds the
+# handle and ``stop`` sends it SIGTERM. These tests drive an *in-flight*
+# recording from a real thread (the fake's ``communicate`` blocks until the
+# recorder signals it) — hermetic (no ffmpeg, no network) but concurrent.
+
+
+def _wait_until(pred, *, timeout: float = 2.0, step: float = 0.01) -> bool:
+    """Spin until ``pred()`` is truthy or ``timeout`` elapses.
+
+    Used to synchronise the test thread with the recording thread without a
+    fixed sleep (which would be either flaky or needlessly slow)."""
+    import time
+
+    elapsed = 0.0
+    while not pred() and elapsed < timeout:
+        time.sleep(step)
+        elapsed += step
+    return pred()
+
+
+def test_stop_terminates_inflight_ffmpeg(tmp_path) -> None:  # noqa: ANN001
+    """Acceptance criterion (#52): ``stop`` must terminate the ffmpeg child,
+    not just flip state. Legacy (job_id) mode: a long recording is in flight
+    on a background thread; the fake ffmpeg blocks until signalled. After
+    ``stop`` the underlying process got ``terminate()``, the state machine is
+    back to ``idle``, and — crucially — the killed partial recording is NOT
+    uploaded to R2 (issue point #2: stop must not leave a phantom job)."""
+    fake_r2 = FakeR2ForRecorder()
+    factory = _popen_factory({"recording.mp4": b"partial"}, auto_exit=False)
+
+    rec = Recorder(
+        uploader=fake_r2,
+        popen_factory=factory,
+        output_dir_factory=lambda job_id: str(tmp_path / job_id),
+        job_id_factory=lambda: "job-stop",
+    )
+
+    thread = threading.Thread(
+        target=lambda: rec.start(url="rtsp://camera.local/stream", duration_s=8 * 3600),
+        daemon=True,
+    )
+    thread.start()
+
+    # Wait until ffmpeg is actually spawned and blocking (state=recording).
+    assert _wait_until(
+        lambda: bool(factory.created) and factory.created[0].entered_wait.is_set()
+    ), "recording never reached the in-flight state"
+    assert rec.status().state == "recording"
+
+    rec.stop()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive(), "start thread should return once ffmpeg is terminated"
+    proc = factory.created[0]
+    assert proc.terminated is True, "stop must SIGTERM the ffmpeg child"
+    assert rec.status().state == "idle"
+    # The operator killed this recording — its partial output must not be
+    # uploaded (would create a phantom job the GPU worker later fails on).
+    assert fake_r2.uploaded == []
+    assert fake_r2.statuses == {}
+
+
+def test_stop_kills_after_grace(tmp_path) -> None:  # noqa: ANN001
+    """A wedged ffmpeg that ignores SIGTERM must not let ``stop`` hang the
+    web thread. After ``stop_grace_s`` the recorder escalates to SIGKILL so
+    the operator's "stop" always completes and the camera always frees up.
+    The fake ignores ``terminate()`` (models the wedged encoder), so the
+    grace ``wait`` times out and ``kill()`` is the only thing that unblocks
+    the recording thread."""
+    fake_r2 = FakeR2ForRecorder()
+    factory = _popen_factory({"recording.mp4": b"x"}, auto_exit=False, ignore_terminate=True)
+
+    rec = Recorder(
+        uploader=fake_r2,
+        popen_factory=factory,
+        output_dir_factory=lambda job_id: str(tmp_path / job_id),
+        job_id_factory=lambda: "job-wedged",
+        stop_grace_s=0.1,  # keep the test fast; production default is 5s
+    )
+
+    thread = threading.Thread(
+        target=lambda: rec.start(url="rtsp://camera.local/stream", duration_s=8 * 3600),
+        daemon=True,
+    )
+    thread.start()
+
+    assert _wait_until(
+        lambda: bool(factory.created) and factory.created[0].entered_wait.is_set()
+    ), "recording never reached the in-flight state"
+
+    rec.stop()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    proc = factory.created[0]
+    assert proc.terminated is True, "stop must try SIGTERM first"
+    assert proc.killed is True, "stop must escalate to SIGKILL when SIGTERM is ignored"
+    assert rec.status().state == "idle"
+
+
+def test_stop_in_buffer_mode_stops_chunk_production(tmp_path) -> None:  # noqa: ANN001
+    """Buffer mode (issue #27) is the appliance's continuous-capture path:
+    ffmpeg writes 60s chunks into the rolling buffer indefinitely. When the
+    platform disables the camera the recorder must actually stop producing
+    chunks — before #52 ffmpeg kept writing for up to ``duration_s`` (default
+    1h). Through the production wrapper (:class:`BackgroundRecorder`): after
+    ``stop`` the ffmpeg child is terminated and ``is_running()`` — the signal
+    ``reconcile_recorders`` polls — reports ``False`` so the slot is free."""
+    from client_agent.recorder import BackgroundRecorder
+
+    factory = _popen_factory({"chunk_000.mp4": b"aaa"}, auto_exit=False)
+    inner = Recorder(
+        uploader=None,  # buffer mode never uploads — the poller does
+        popen_factory=factory,
+        output_dir_factory=lambda cam_id: str(tmp_path / "buffer" / cam_id),
+    )
+    bg = BackgroundRecorder(inner)
+
+    bg.start(url="rtsp://camera.local/stream", duration_s=8 * 3600, camera_id="cam-front")
+
+    assert _wait_until(
+        lambda: bool(factory.created) and factory.created[0].entered_wait.is_set()
+    ), "buffer recording never reached the in-flight state"
+    assert bg.is_running() is True
+
+    bg.stop()
+
+    assert _wait_until(lambda: not bg.is_running()), "recorder still running after stop"
+    proc = factory.created[0]
+    assert proc.terminated is True, "buffer-mode stop must terminate the ffmpeg child"
+    assert bg.is_running() is False
 
 
 # ----- BackgroundRecorder thread survival + is_running contract -----
@@ -576,8 +791,12 @@ def test_background_recorder_is_running_false_when_thread_exits_via_exception(
     from client_agent.recorder import BackgroundRecorder, Recorder
 
     class _Boom(Recorder):
-        def start(  # type: ignore[override]
-            self, *, url: str, duration_s: int, camera_id: str | None = None
+        # ``BackgroundRecorder`` reserves the slot synchronously then runs the
+        # ffmpeg work via ``_run`` on the daemon thread (issue #52 TOCTOU fix),
+        # so the simulated crash must come from ``_run`` to exercise the
+        # daemon-thread exception path.
+        def _run(  # type: ignore[override]
+            self, job_id: str, *, url: str, duration_s: int, camera_id: str | None
         ) -> str:
             raise RuntimeError("simulated ffmpeg crash on RTSP drop")
 
@@ -615,3 +834,61 @@ def test_background_recorder_is_running_false_before_start() -> None:
     )
     bg = BackgroundRecorder(inner)
     assert bg.is_running() is False
+
+
+def test_concurrent_start_second_caller_gets_busy(tmp_path) -> None:  # noqa: ANN001
+    """Issue #52 (#4): ``BackgroundRecorder.start`` must claim the single
+    recording slot SYNCHRONOUSLY on the caller's (HTTP) thread. The old code
+    only pre-checked a stale ``status()`` then spawned a daemon thread, so two
+    near-simultaneous ``/start`` calls both passed the check and the loser
+    raised ``RecorderBusy`` invisibly *inside* its daemon thread — its HTTP
+    caller had already been told the recording was scheduled.
+
+    A purely sequential test can't expose that race (the daemon reliably flips
+    state before the second call), so we pin the *mechanism*: the slot claim
+    (the ``idle → recording`` flip, which computes the ``job_id``) must happen
+    on the caller's own thread before ``start`` returns. We observe that via
+    the injected ``job_id_factory``:
+
+    * fixed → the factory ran on the test (caller) thread → the reservation is
+      synchronous → a second caller is rejected on its own thread.
+    * broken → the factory ran on the daemon thread (or hadn't run yet when
+      ``start`` returned) → the rejection would surface only in the daemon.
+    """
+    import pytest
+
+    from client_agent.recorder import BackgroundRecorder
+
+    caller = threading.current_thread()
+    reserve_threads: list[threading.Thread] = []
+
+    def _job_id_factory() -> str:
+        reserve_threads.append(threading.current_thread())
+        return "job-1"
+
+    # First recording stays in flight (blocks) so the slot is genuinely busy
+    # while the second caller races in. Legacy mode so the reservation calls
+    # ``job_id_factory`` (buffer mode would key on camera_id instead).
+    factory = _popen_factory({"recording.mp4": b"x"}, auto_exit=False)
+    inner = Recorder(
+        uploader=FakeR2ForRecorder(),
+        popen_factory=factory,
+        output_dir_factory=lambda job_id: str(tmp_path / job_id),
+        job_id_factory=_job_id_factory,
+    )
+    bg = BackgroundRecorder(inner)
+
+    bg.start(url="rtsp://camera.local/1", duration_s=8 * 3600)
+
+    # The slot was claimed synchronously, on THIS thread, before start returned.
+    assert reserve_threads == [caller], "reservation must run on the caller thread"
+    assert bg.status().state == "recording"
+
+    # A second caller must be rejected on THIS thread, not inside a daemon —
+    # and without invoking job_id_factory again (busy check comes first).
+    with pytest.raises(RecorderBusy):
+        bg.start(url="rtsp://camera.local/2", duration_s=8 * 3600)
+    assert reserve_threads == [caller], "a rejected start must not claim a job_id"
+
+    # Tear down: stop the first recording so its daemon thread exits cleanly.
+    bg.stop()


### PR DESCRIPTION
Closes #52.

## Problem
`Recorder.start` ran ffmpeg via a blocking `subprocess.run` with no process handle, so `stop()` only flipped in-memory state to `idle` while ffmpeg kept capturing RTSP and writing chunks for up to `duration_s` (default 3600s). For a CCTV product, "stop recording" must mean recording stops now.

Consequences fixed:
- **Privacy/compliance:** platform-disable (`reconcile_recorders`) now SIGTERMs the ffmpeg child instead of dropping a still-running handle.
- **Lying UI:** `POST /stop` no longer returns 200 while ffmpeg keeps writing; a killed legacy recording is discarded, not uploaded to R2.
- **Concurrent-start TOCTOU:** `BackgroundRecorder` reserves the recording slot synchronously on the caller (HTTP) thread, so a second `/start` is rejected with `RecorderBusy` (→409) instead of raising invisibly inside the loser's daemon thread.

## Implementation
- Recording moves to an injectable `popen_factory` (default `subprocess.Popen`); the recorder keeps the handle under its lock. `probe` still uses the `subprocess.run`-shaped `runner` (bounded, needs `TimeoutExpired`).
- `stop()`: `terminate` → `wait(stop_grace_s)` → `kill`; sets a `_cancelled` flag so the recording thread skips upload on an operator/platform stop. Race-safe against a stop that beats the spawn (`start` honours `_cancelled` right after publishing the handle).
- `Recorder.start` split into `_reserve()` (atomic idle→recording claim) + `_run()` (ffmpeg work); `BackgroundRecorder` reserves on the HTTP thread, runs `_run` on the daemon thread.

## Tests (TDD, RED→GREEN, hermetic via a Popen-shaped `FakePopen` + real threads)
- `test_stop_terminates_inflight_ffmpeg` (legacy) — terminate, state idle, no upload
- `test_stop_kills_after_grace` — SIGKILL escalation when SIGTERM ignored
- `test_stop_in_buffer_mode_stops_chunk_production` — buffer mode + `is_running()`→False
- `test_run_platform_session_disable_terminates_underlying_ffmpeg` (appliance) — reconcile disable terminates the real child
- `test_concurrent_start_second_caller_gets_busy` — synchronous reservation → one busy

323 tests pass (client-agent + client-appliance + meta), ruff clean.

## E2E on cctv-vps
Against a live mediamtx RTSP source with real ffmpeg: 8h buffer recording, `stop()` terminated the ffmpeg child in **0.11s** (grace 5s), `is_running()`→False, no orphan process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)