### PR TITLE
fix(client-agent): re-attach RTSP creds for the buffer recorder

### DIFF
--- a/client-agent/client_agent/appliance.py
+++ b/client-agent/client_agent/appliance.py
@@ -26,12 +26,17 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from waitress import serve
 
 from client_agent.agent import build_app
 from client_agent.buffer import RollingBuffer
-from client_agent.discovery import DiscoveredCamera
+from client_agent.discovery import (
+    DiscoveredCamera,
+    inject_credentials,
+    resolve_camera_credentials,
+)
 from client_agent.ffmpeg_trim import trim_and_concat
 from client_agent.platform import HeartbeatResponse, PlatformClient
 from client_agent.poller import TaskPoller
@@ -48,6 +53,25 @@ logger = logging.getLogger(__name__)
 # ``recorder.SEGMENT_SECONDS`` so a short camera reactivation doesn't
 # cross a chunk boundary unnecessarily.
 DEFAULT_RECORDING_DURATION_S = 3600
+
+
+def authenticated_rtsp_url(url: str, environ: Mapping[str, str]) -> str:
+    """Re-attach RTSP credentials to a platform-stored (credential-free) URL so
+    the buffer recorder's ffmpeg can authenticate.
+
+    The platform strips userinfo from every stored ``rtsp_url`` (issue #22), so a
+    recorder started straight off ``response.config.cameras`` gets ``401`` on any
+    ONVIF-discovered camera — ``GetStreamUri`` returns a bare
+    ``rtsp://host:port/path`` — whose creds live in ``cameras.env``. The recorder
+    then exits and respawns forever, buffering nothing. Resolve the per-host creds
+    from ``environ`` and inject them. No-op when the URL already carries userinfo
+    or no creds are configured for the host, so it is safe to apply to every
+    camera the platform hands back.
+    """
+    parsed = urlparse(url)
+    if parsed.username or not parsed.hostname:
+        return url
+    return inject_credentials(url, resolve_camera_credentials(parsed.hostname, environ))
 
 
 def _camera_to_push_dict(cam: DiscoveredCamera) -> dict[str, Any]:
@@ -296,7 +320,7 @@ def run_platform_session(
     def _spawn(cam: dict) -> Any:
         rec = recorder_factory()
         rec.start(
-            url=cam["rtsp_url"],
+            url=authenticated_rtsp_url(cam["rtsp_url"], environ),
             duration_s=int(cam.get("duration_s", DEFAULT_RECORDING_DURATION_S)),
             camera_id=cam["id"],
         )
@@ -580,7 +604,6 @@ def main(argv: Sequence[str] | None = None) -> None:
             discover_cameras,
             make_real_rtsp_scan,
             make_real_tuya_scan,
-            resolve_camera_credentials,
         )
 
         env_snapshot = dict(os.environ)

--- a/client-agent/client_agent/appliance_test.py
+++ b/client-agent/client_agent/appliance_test.py
@@ -103,6 +103,46 @@ def test_load_env_files_skips_blank_lines_and_comments(tmp_path: Path) -> None:
     assert environ == {"RTSP_DEFAULT_USER": "admin"}
 
 
+# ----- authenticated_rtsp_url: re-attach cameras.env creds for the buffer recorder -----
+
+
+def test_authenticated_rtsp_url_injects_creds_from_environ() -> None:
+    """The platform hands back credential-free URLs (#22); the buffer recorder
+    must re-attach the operator's ``cameras.env`` creds or ffmpeg 401s on every
+    ONVIF-discovered camera and the recorder respawns forever, buffering nothing.
+    Password specials are percent-encoded."""
+    from client_agent.appliance import authenticated_rtsp_url
+
+    environ = {"RTSP_DEFAULT_USER": "admin", "RTSP_DEFAULT_PASS": "#J2Zxs9b0iMP"}
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+
+    assert (
+        authenticated_rtsp_url(url, environ)
+        == "rtsp://admin:%23J2Zxs9b0iMP@192.168.88.89:554/unicast/c1/s0/live"
+    )
+
+
+def test_authenticated_rtsp_url_noop_when_no_creds_configured() -> None:
+    """No creds in the environ for the host → URL returned untouched (ffmpeg's
+    401 is a clearer signal than a silent rewrite)."""
+    from client_agent.appliance import authenticated_rtsp_url
+
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+
+    assert authenticated_rtsp_url(url, {}) == url
+
+
+def test_authenticated_rtsp_url_noop_when_already_credentialed() -> None:
+    """A URL that already carries userinfo (e.g. a hardcoded per-camera URL) is
+    left alone, so the env default creds never clobber an explicit one."""
+    from client_agent.appliance import authenticated_rtsp_url
+
+    environ = {"RTSP_DEFAULT_USER": "admin", "RTSP_DEFAULT_PASS": "envpass"}
+    url = "rtsp://cam:hardcoded@192.168.1.198:554/V_ENC_000"
+
+    assert authenticated_rtsp_url(url, environ) == url
+
+
 # ----- 2. default_recordings_dir: XDG state dir -----
 
 

--- a/client-agent/client_agent/discovery.py
+++ b/client-agent/client_agent/discovery.py
@@ -234,6 +234,36 @@ def strip_credentials_from_url(url: str) -> str:
     return parsed._replace(netloc=netloc).geturl()
 
 
+def inject_credentials(url: str, credentials: tuple[str, str] | None) -> str:
+    """Re-attach ``user:pass@`` userinfo to an ``rtsp://`` URL.
+
+    The exact inverse of :func:`strip_credentials_from_url`. The platform stores
+    every stream URL credential-free (issue #22), so any consumer that must
+    actually *open* the stream — the buffer recorder handing the URL to ffmpeg —
+    has to re-attach the operator's ``cameras.env`` creds first. Without this an
+    ONVIF-discovered camera (whose ``GetStreamUri`` returns a bare
+    ``rtsp://host:port/path``) makes ffmpeg 401 and the recorder dies on loop.
+
+    No-op when ``credentials is None`` or the URL already carries userinfo (so it
+    is safe to apply unconditionally). The password is percent-encoded
+    (``quote(safe='')``, matching :func:`build_rtsp_url`) so specials like ``#``,
+    ``@`` and ``:`` survive URL parsing downstream.
+    """
+    if credentials is None:
+        return url
+    parsed = urlparse(url)
+    if parsed.username or parsed.password or not parsed.hostname:
+        return url
+    from urllib.parse import quote
+
+    user, password = credentials
+    userinfo = f"{quote(user, safe='')}:{quote(password, safe='')}@"
+    netloc = f"{userinfo}{parsed.hostname}"
+    if parsed.port is not None:
+        netloc = f"{userinfo}{parsed.hostname}:{parsed.port}"
+    return parsed._replace(netloc=netloc).geturl()
+
+
 def guess_vendor_from_open_ports(open_ports: set[int]) -> str:
     """Secondary vendor fingerprint based on management-port presence.
 

--- a/client-agent/client_agent/discovery_test.py
+++ b/client-agent/client_agent/discovery_test.py
@@ -461,6 +461,58 @@ def test_strip_credentials_preserves_path_with_at_sign() -> None:
     assert strip_credentials_from_url(url) == url
 
 
+def test_inject_credentials_adds_userinfo_to_bare_url() -> None:
+    """Inverse of strip: the platform stores credential-free URLs (#22), so a
+    consumer that must open the stream (the buffer recorder → ffmpeg) has to
+    re-attach ``cameras.env`` creds first. An ONVIF ``GetStreamUri`` result is
+    bare — without this it 401s and the recorder respawns forever."""
+    from client_agent.discovery import inject_credentials
+
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+    assert (
+        inject_credentials(url, ("admin", "secret"))
+        == "rtsp://admin:secret@192.168.88.89:554/unicast/c1/s0/live"
+    )
+
+
+def test_inject_credentials_url_encodes_special_password() -> None:
+    """Specials in the password (``#``/``@``/``:``) are percent-encoded so the
+    resulting URL parses correctly downstream (ffmpeg, the recorder)."""
+    from client_agent.discovery import inject_credentials
+
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+    assert (
+        inject_credentials(url, ("admin", "#J2Zxs9b0iMP"))
+        == "rtsp://admin:%23J2Zxs9b0iMP@192.168.88.89:554/unicast/c1/s0/live"
+    )
+
+
+def test_inject_credentials_noop_when_credentials_none() -> None:
+    """No creds configured for the host → return the URL untouched."""
+    from client_agent.discovery import inject_credentials
+
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+    assert inject_credentials(url, None) == url
+
+
+def test_inject_credentials_noop_when_url_already_credentialed() -> None:
+    """Idempotent: a URL already carrying userinfo is left alone, so applying
+    inject unconditionally can't double-stamp creds."""
+    from client_agent.discovery import inject_credentials
+
+    url = "rtsp://admin:secret@192.168.88.89:554/unicast/c1/s0/live"
+    assert inject_credentials(url, ("other", "creds")) == url
+
+
+def test_inject_credentials_round_trips_with_strip() -> None:
+    """``strip(inject(url, creds)) == url`` — the two helpers are exact inverses,
+    which is the whole #22 store-stripped / use-injected contract."""
+    from client_agent.discovery import inject_credentials, strip_credentials_from_url
+
+    url = "rtsp://192.168.88.89:554/unicast/c1/s0/live"
+    assert strip_credentials_from_url(inject_credentials(url, ("admin", "#J2Zxs9b0iMP"))) == url
+
+
 # ===== Credentials resolver wired into discover_cameras =====
 
 


### PR DESCRIPTION
## Bug

The platform-mode buffer recorder handed the **credential-free** stream URL straight to ffmpeg. Any ONVIF-discovered camera (`GetStreamUri` returns a bare `rtsp://host:port/path`) makes ffmpeg 401 → the recorder exits and respawns forever, buffering nothing. When a task later trims from that empty buffer there is no footage to analyze.

Root cause: the platform stores every stream URL credential-free (#22 strips creds on store), and the Docker `/start` path re-attaches creds from the env resolver — but `appliance.py::_spawn` → `Recorder` had **no** creds-resolver wired. The `.198` demo camera only worked because its URL was hardcoded with `admin:kk1234@`.

## Fix

- **`discovery.py`**: add `inject_credentials(url, credentials)` — the exact inverse of `strip_credentials_from_url`. Percent-encodes user + password so a `#`/`@`/`:`-leading password survives; no-ops when the URL already carries credentials or has no host.
- **`appliance.py`**: `authenticated_rtsp_url(url, environ)` resolves per-host creds from `cameras.env` (`resolve_camera_credentials`) and injects them; `_spawn` runs the stored URL through it before starting the recorder.

## Tests

- `inject_credentials`: adds userinfo · URL-encodes `#J2Zxs9b0iMP` → `%23J2Zxs9b0iMP` · no-op on `None` · no-op when already credentialed · round-trips with `strip_credentials_from_url`.
- `authenticated_rtsp_url`: injects from environ · no-op when no creds configured · no-op when URL already credentialed.

`101 passed` (full discovery + appliance suites) · `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)