### PR TITLE
fix(gpu-service): select freest GPU at preflight instead of hardcoding GPU 0

### DIFF
--- a/gpu-service/gpu_service/vram_preflight.py
+++ b/gpu-service/gpu_service/vram_preflight.py
@@ -1,22 +1,51 @@
-"""Pre-flight VRAM check for the gpu-service container (issue #43).
+"""Pre-flight VRAM check + GPU selection for the gpu-service container.
 
-Operators previously saw mid-load PyTorch OOM tracebacks when another CUDA
-process held most of the GPU. This module turns that into a one-line,
-structured fail-fast at container startup.
+Two jobs, run once at container startup before any model loads:
+
+1. **Select** the visible GPU with the most free VRAM and pin every downstream
+   CUDA consumer to it via ``CUDA_VISIBLE_DEVICES=<uuid>``. This lets the box
+   host a warm SGLang LLM on one GPU while CCTV inference lands on the free one
+   — no static per-GPU assignment, the container adapts to whatever's free.
+2. **Fail fast** (issue #43) if *no* GPU has enough free VRAM: one structured
+   ``VRAM_PREFLIGHT_FAIL …`` stderr line + ``exit(2)`` instead of a mid-load
+   PyTorch OOM traceback that masks the real cause (another CUDA process).
+
+The free-VRAM query goes through ``nvidia-smi`` (NVML), *not* torch — so no
+CUDA context is created here. That's what makes the ``CUDA_VISIBLE_DEVICES``
+pin effective: it is set before torch/onnxruntime first initialise CUDA, so
+their default ``cuda:0`` / ``device_id=0`` transparently maps to the chosen
+physical GPU. UUID (not index) is used so the pin is immune to device ordering.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import subprocess
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, MutableMapping
+from dataclasses import dataclass
 from typing import IO
 
-MemGetInfo = Callable[[], tuple[int, int]]
+logger = logging.getLogger(__name__)
+
 _MIB = 1024 * 1024
 
 
 class InsufficientVRAMError(Exception):
-    """Free VRAM is below the configured budget for this classifier."""
+    """No visible GPU has enough free VRAM for the configured budget."""
+
+
+class NoGpuError(Exception):
+    """nvidia-smi reported no usable GPU (or is unavailable)."""
+
+
+@dataclass(frozen=True)
+class GpuInfo:
+    index: int
+    uuid: str
+    free_mb: int
+    total_mb: int
 
 
 # Per-classifier VRAM budgets (MiB). Source: warm-load occupancy on a clean
@@ -27,6 +56,8 @@ DEFAULT_BUDGETS_MB: dict[str, int] = {
     "vlm": 7168,
 }
 
+QueryGpus = Callable[[], list[GpuInfo]]
+
 
 def resolve_required_mb(classifier: str, env_override: str | None) -> int:
     """Decide the budget for this run: env var beats classifier default."""
@@ -35,45 +66,105 @@ def resolve_required_mb(classifier: str, env_override: str | None) -> int:
     return DEFAULT_BUDGETS_MB[classifier]
 
 
-def _default_mem_get_info() -> tuple[int, int]:
-    """Lazy-import torch.cuda so unit tests don't pull onnxruntime / cu128."""
-    import torch
+def parse_nvidia_smi(csv_text: str) -> list[GpuInfo]:
+    """Parse ``index,uuid,memory.free,memory.total`` CSV rows (nounits → MiB).
 
-    return torch.cuda.mem_get_info(0)
+    Blank lines and short/garbled rows are skipped rather than raising — a
+    partial parse still lets ``select_best_gpu`` pick from the usable GPUs.
+    """
+    gpus: list[GpuInfo] = []
+    for raw in csv_text.strip().splitlines():
+        parts = [p.strip() for p in raw.split(",")]
+        if len(parts) < 4:
+            continue
+        try:
+            gpus.append(
+                GpuInfo(
+                    index=int(parts[0]),
+                    uuid=parts[1],
+                    free_mb=int(parts[2]),
+                    total_mb=int(parts[3]),
+                )
+            )
+        except ValueError:
+            continue
+    return gpus
+
+
+def _default_query_gpus() -> list[GpuInfo]:
+    """Query every visible GPU's free VRAM via nvidia-smi (no CUDA context)."""
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,uuid,memory.free,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise NoGpuError(f"nvidia-smi unavailable: {exc}") from exc
+    return parse_nvidia_smi(completed.stdout)
+
+
+def select_best_gpu(gpus: list[GpuInfo]) -> GpuInfo:
+    """The GPU with the most free VRAM; ties break to the lowest index."""
+    if not gpus:
+        raise NoGpuError("nvidia-smi reported no GPU")
+    return max(gpus, key=lambda g: (g.free_mb, -g.index))
 
 
 def preflight_or_exit(
     classifier: str,
     env_override: str | None,
-    mem_get_info: MemGetInfo | None = None,
+    query_gpus: QueryGpus | None = None,
+    environ: MutableMapping[str, str] | None = None,
     stderr: IO[str] = sys.stderr,
     exit_fn: Callable[[int], None] = sys.exit,
 ) -> None:
-    """Run the VRAM check at container entrypoint.
+    """Select the freest GPU and pin CUDA to it, or fail fast.
 
-    On insufficient VRAM: write one ``VRAM_PREFLIGHT_FAIL …`` line to stderr
-    (flushed, single line so gpu-agent's failure capture stays clean) and call
-    ``exit_fn(2)``. On success: no output, no exit — caller proceeds to load
-    models. Both ``mem_get_info`` and ``exit_fn`` are injectable for tests.
+    On success: sets ``CUDA_VISIBLE_DEVICES`` to the chosen GPU's UUID and
+    returns (no stderr output). On no-GPU or insufficient-VRAM: writes one
+    ``VRAM_PREFLIGHT_FAIL …`` line to ``stderr`` and calls ``exit_fn(2)``.
+    ``query_gpus``, ``environ``, and ``exit_fn`` are injectable for tests.
     """
     required = resolve_required_mb(classifier, env_override)
-    if mem_get_info is None:
-        mem_get_info = _default_mem_get_info
+    if query_gpus is None:
+        query_gpus = _default_query_gpus
+    if environ is None:
+        environ = os.environ
+
     try:
-        check_vram_budget(required, mem_get_info)
-    except InsufficientVRAMError as exc:
+        gpus = query_gpus()
+        best = select_best_gpu(gpus)
+        if best.free_mb < required:
+            raise InsufficientVRAMError(
+                f"insufficient VRAM: required={required} MiB; freest of {len(gpus)} "
+                f"GPU(s) is GPU {best.index} with free={best.free_mb} MiB, "
+                f"total={best.total_mb} MiB. "
+                f"Another CUDA process is likely consuming VRAM; "
+                f"nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv"
+            )
+    except (InsufficientVRAMError, NoGpuError) as exc:
         print(f"VRAM_PREFLIGHT_FAIL {exc}", file=stderr, flush=True)
         exit_fn(2)
+        return
 
-
-def check_vram_budget(required_mb: int, mem_get_info: MemGetInfo) -> None:
-    free_bytes, total_bytes = mem_get_info()
-    free_mb = free_bytes // _MIB
-    total_mb = total_bytes // _MIB
-    if free_mb < required_mb:
-        raise InsufficientVRAMError(
-            f"insufficient VRAM on GPU 0: required={required_mb} MiB, "
-            f"free={free_mb} MiB, total={total_mb} MiB. "
-            f"Another CUDA process is likely consuming VRAM; "
-            f"nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv"
-        )
+    # Pin every downstream CUDA consumer (torch cuda:0, onnxruntime device_id=0)
+    # to the chosen GPU. Set BEFORE the first torch import initialises CUDA —
+    # rest_server/worker call this before _warm_up_pipeline, so the pin holds.
+    environ["CUDA_VISIBLE_DEVICES"] = best.uuid
+    logger.info(
+        "VRAM preflight: selected GPU %d (%s) free=%d MiB of %d MiB "
+        "for classifier=%s (required=%d MiB)",
+        best.index,
+        best.uuid,
+        best.free_mb,
+        best.total_mb,
+        classifier,
+        required,
+    )

--- a/gpu-service/gpu_service/vram_preflight_test.py
+++ b/gpu-service/gpu_service/vram_preflight_test.py
@@ -1,11 +1,17 @@
-"""Tests for the VRAM pre-flight check (issue #43).
+"""Tests for the VRAM pre-flight check + GPU selection.
 
-Goal: replace the multi-line PyTorch OOM trace operators currently see when
-another CUDA process holds VRAM with a single, structured ``VRAM_PREFLIGHT_FAIL``
-line and a hard ``exit(2)`` before any model load is attempted.
+Two behaviours under test:
 
-Tests inject ``mem_get_info`` (the only system boundary) so they run on the
-macOS CPU dev box without onnxruntime / torch.cuda.
+* **Selection** — of the visible GPUs, the one with the most free VRAM wins,
+  and its UUID is pinned into ``CUDA_VISIBLE_DEVICES`` so the pipeline's default
+  ``cuda:0`` lands there. This is what lets a warm SGLang LLM on GPU 0 coexist
+  with CCTV inference on GPU 1.
+* **Fail-fast** (issue #43) — when *no* GPU clears the budget (or none exists),
+  one structured ``VRAM_PREFLIGHT_FAIL`` line + ``exit(2)`` instead of a
+  multi-line PyTorch OOM trace.
+
+The system boundary (``nvidia-smi``) is injected as ``query_gpus`` so tests run
+on the macOS CPU dev box with no torch / driver.
 """
 
 from __future__ import annotations
@@ -15,52 +21,17 @@ import io
 import pytest
 
 from gpu_service.vram_preflight import (
-    InsufficientVRAMError,
-    check_vram_budget,
+    GpuInfo,
+    NoGpuError,
+    parse_nvidia_smi,
     preflight_or_exit,
     resolve_required_mb,
+    select_best_gpu,
 )
-
-MIB = 1024 * 1024
-
-
-class TestCheckVramBudget:
-    def test_raises_when_free_below_required(self) -> None:
-        # The exact numbers from the source incident: 139 MiB free of 12 GiB,
-        # required budget for VLM = 7168 MiB.
-        free_bytes = 139 * MIB
-        total_bytes = 12 * 1024 * MIB
-
-        with pytest.raises(InsufficientVRAMError) as exc_info:
-            check_vram_budget(
-                required_mb=7168,
-                mem_get_info=lambda: (free_bytes, total_bytes),
-            )
-
-        msg = str(exc_info.value)
-        assert "required=7168" in msg
-        assert "free=139" in msg
-        assert "total=12288" in msg
-
-    def test_passes_silently_when_free_above_required(self) -> None:
-        # 8 GiB free, 12 GiB total, required=7168 — typical clean-GPU case.
-        result = check_vram_budget(
-            required_mb=7168,
-            mem_get_info=lambda: (8 * 1024 * MIB, 12 * 1024 * MIB),
-        )
-        assert result is None
-
-    def test_passes_when_free_equals_required(self) -> None:
-        # Exact-equal is acceptable — the budget already includes headroom.
-        check_vram_budget(
-            required_mb=1024,
-            mem_get_info=lambda: (1024 * MIB, 12 * 1024 * MIB),
-        )
 
 
 class TestResolveRequiredMb:
     def test_env_override_wins_over_classifier_default(self) -> None:
-        # Operator override path: VRAM_BUDGET_MB beats the per-classifier default.
         assert resolve_required_mb(classifier="vlm", env_override="2048") == 2048
         assert resolve_required_mb(classifier="heuristic", env_override="9999") == 9999
 
@@ -71,72 +42,171 @@ class TestResolveRequiredMb:
         assert resolve_required_mb(classifier="vlm", env_override=None) == 7168
 
     def test_empty_string_env_override_falls_back_to_classifier_default(self) -> None:
-        # Docker's missing-env vs empty-env distinction: os.environ.get returns
-        # "" for `-e VRAM_BUDGET_MB=`. Treat empty as "not set" — otherwise
-        # int("") raises and a forgotten empty flag would crash boot.
+        # Docker's missing-env vs empty-env distinction: `-e VRAM_BUDGET_MB=`
+        # gives "". Treat as "not set" — otherwise int("") crashes boot.
         assert resolve_required_mb(classifier="vlm", env_override="") == 7168
 
 
+class TestParseNvidiaSmi:
+    def test_parses_multiple_gpus(self) -> None:
+        # Real shape of `--query-gpu=index,uuid,memory.free,memory.total
+        # --format=csv,noheader,nounits` on a 2-GPU box.
+        csv = "0, GPU-aaaa, 2447, 11774\n1, GPU-bbbb, 11772, 11774\n"
+        gpus = parse_nvidia_smi(csv)
+        assert gpus == [
+            GpuInfo(index=0, uuid="GPU-aaaa", free_mb=2447, total_mb=11774),
+            GpuInfo(index=1, uuid="GPU-bbbb", free_mb=11772, total_mb=11774),
+        ]
+
+    def test_skips_blank_and_garbled_rows(self) -> None:
+        csv = "\n0, GPU-aaaa, 8000, 12000\ngarbage-line\n1, GPU-bbbb, notanint, 12000\n"
+        gpus = parse_nvidia_smi(csv)
+        assert gpus == [GpuInfo(index=0, uuid="GPU-aaaa", free_mb=8000, total_mb=12000)]
+
+    def test_empty_output_yields_no_gpus(self) -> None:
+        assert parse_nvidia_smi("") == []
+
+
+class TestSelectBestGpu:
+    def test_picks_gpu_with_most_free_vram(self) -> None:
+        gpus = [
+            GpuInfo(index=0, uuid="GPU-aaaa", free_mb=2447, total_mb=11774),
+            GpuInfo(index=1, uuid="GPU-bbbb", free_mb=11772, total_mb=11774),
+        ]
+        assert select_best_gpu(gpus).index == 1
+
+    def test_ties_break_to_lowest_index(self) -> None:
+        gpus = [
+            GpuInfo(index=1, uuid="GPU-bbbb", free_mb=8000, total_mb=12000),
+            GpuInfo(index=0, uuid="GPU-aaaa", free_mb=8000, total_mb=12000),
+        ]
+        assert select_best_gpu(gpus).index == 0
+
+    def test_no_gpu_raises(self) -> None:
+        with pytest.raises(NoGpuError):
+            select_best_gpu([])
+
+
+def _fixed(gpus: list[GpuInfo]):
+    return lambda: gpus
+
+
 class TestPreflightOrExit:
-    def test_insufficient_vram_exits_2_with_structured_stderr_line(self) -> None:
-        # Faithful reproduction of the source incident: 139 MiB free of 12 GiB,
-        # VLM budget 7168 MiB. Operator should see one line, then exit(2).
+    def test_selects_free_gpu_and_pins_cuda_visible_devices(self) -> None:
+        # Source incident layout: SGLang on GPU 0 (2447 MiB free), GPU 1 empty.
+        # vlm needs 7168 — must pick GPU 1 and pin its UUID.
+        gpus = [
+            GpuInfo(index=0, uuid="GPU-sglang", free_mb=2447, total_mb=11774),
+            GpuInfo(index=1, uuid="GPU-free", free_mb=11772, total_mb=11774),
+        ]
+        environ: dict[str, str] = {}
         stderr = io.StringIO()
         exit_calls: list[int] = []
-
-        def fake_exit(code: int) -> None:
-            exit_calls.append(code)
 
         preflight_or_exit(
             classifier="vlm",
             env_override=None,
-            mem_get_info=lambda: (139 * MIB, 12 * 1024 * MIB),
+            query_gpus=_fixed(gpus),
+            environ=environ,
             stderr=stderr,
-            exit_fn=fake_exit,
+            exit_fn=exit_calls.append,
+        )
+
+        assert exit_calls == []
+        assert stderr.getvalue() == ""
+        assert environ["CUDA_VISIBLE_DEVICES"] == "GPU-free"
+
+    def test_single_free_gpu_is_pinned(self) -> None:
+        gpus = [GpuInfo(index=0, uuid="GPU-only", free_mb=11772, total_mb=11774)]
+        environ: dict[str, str] = {}
+        preflight_or_exit(
+            classifier="vlm",
+            env_override=None,
+            query_gpus=_fixed(gpus),
+            environ=environ,
+            stderr=io.StringIO(),
+            exit_fn=lambda _c: None,
+        )
+        assert environ["CUDA_VISIBLE_DEVICES"] == "GPU-only"
+
+    def test_all_gpus_busy_exits_2_with_structured_line(self) -> None:
+        # Both GPUs occupied below the vlm budget → fail fast, no CUDA pin.
+        gpus = [
+            GpuInfo(index=0, uuid="GPU-aaaa", free_mb=2447, total_mb=11774),
+            GpuInfo(index=1, uuid="GPU-bbbb", free_mb=139, total_mb=11774),
+        ]
+        environ: dict[str, str] = {}
+        stderr = io.StringIO()
+        exit_calls: list[int] = []
+
+        preflight_or_exit(
+            classifier="vlm",
+            env_override=None,
+            query_gpus=_fixed(gpus),
+            environ=environ,
+            stderr=stderr,
+            exit_fn=exit_calls.append,
         )
 
         assert exit_calls == [2]
         line = stderr.getvalue()
         assert line.startswith("VRAM_PREFLIGHT_FAIL ")
         assert "required=7168" in line
-        assert "free=139" in line
-        assert "total=12288" in line
-        # nvidia-smi hint must be in the line so operator has a one-glance
-        # next step rather than searching docs for what to run.
+        # Reports the *freest* GPU (the best candidate that still failed).
+        assert "free=2447" in line
         assert "nvidia-smi" in line
-        # One line only — no PyTorch traceback bleeding through.
-        assert line.count("\n") == 1
+        assert line.count("\n") == 1  # one line only — no torch traceback
+        assert "CUDA_VISIBLE_DEVICES" not in environ
 
-    def test_sufficient_vram_proceeds_silently(self) -> None:
-        # Healthy GPU: 8 GiB free of 12 GiB, vlm needs 7168. Caller must reach
-        # the next instruction with no stderr noise and no exit.
+    def test_no_gpu_visible_exits_2(self) -> None:
+        environ: dict[str, str] = {}
         stderr = io.StringIO()
         exit_calls: list[int] = []
 
         preflight_or_exit(
             classifier="vlm",
             env_override=None,
-            mem_get_info=lambda: (8 * 1024 * MIB, 12 * 1024 * MIB),
+            query_gpus=_fixed([]),
+            environ=environ,
             stderr=stderr,
             exit_fn=exit_calls.append,
         )
 
-        assert exit_calls == []
-        assert stderr.getvalue() == ""
+        assert exit_calls == [2]
+        assert stderr.getvalue().startswith("VRAM_PREFLIGHT_FAIL ")
+        assert "CUDA_VISIBLE_DEVICES" not in environ
 
-    def test_env_override_drives_the_check(self) -> None:
-        # Operator sets VRAM_BUDGET_MB=200 to force-allow a tight box; 256 MiB
-        # free should now PASS even though it's far below the vlm default.
+    def test_query_raising_no_gpu_error_exits_2(self) -> None:
+        # nvidia-smi unavailable (raises NoGpuError) must fail fast, not crash.
+        def boom() -> list[GpuInfo]:
+            raise NoGpuError("nvidia-smi unavailable: [Errno 2] No such file")
+
         stderr = io.StringIO()
         exit_calls: list[int] = []
+        preflight_or_exit(
+            classifier="vlm",
+            env_override=None,
+            query_gpus=boom,
+            environ={},
+            stderr=stderr,
+            exit_fn=exit_calls.append,
+        )
+        assert exit_calls == [2]
+        assert stderr.getvalue().startswith("VRAM_PREFLIGHT_FAIL ")
 
+    def test_env_override_relaxes_budget(self) -> None:
+        # Operator forces a tight box: VRAM_BUDGET_MB=200 → a 256-MiB-free GPU
+        # now passes and gets pinned.
+        gpus = [GpuInfo(index=0, uuid="GPU-tight", free_mb=256, total_mb=12000)]
+        environ: dict[str, str] = {}
+        exit_calls: list[int] = []
         preflight_or_exit(
             classifier="vlm",
             env_override="200",
-            mem_get_info=lambda: (256 * MIB, 12 * 1024 * MIB),
-            stderr=stderr,
+            query_gpus=_fixed(gpus),
+            environ=environ,
+            stderr=io.StringIO(),
             exit_fn=exit_calls.append,
         )
-
         assert exit_calls == []
-        assert stderr.getvalue() == ""
+        assert environ["CUDA_VISIBLE_DEVICES"] == "GPU-tight"


### PR DESCRIPTION
## Bug (production E2E, 2026-07-10)

A surveillance task was claimed by **cctv-vps** (the `always_ai` warm-LLM host) and failed with `container healthcheck timeout after 60000ms`. Root cause: the gpu-service container's VRAM preflight only checked **GPU 0** (`torch.cuda.mem_get_info(0)`) and every model loaded on `cuda:0`. SGLang holds ~9.15 GB on **GPU 0**, so the 7168 MiB VLM preflight failed, the container `exit(2)`'d before `/healthz` came up, and `--rm` removed it — leaving only the platform-side healthcheck timeout as evidence.

GPU 1 sat empty the whole time.

## Fix

The preflight now **selects the freest GPU** instead of hardcoding GPU 0:

- Enumerate every visible GPU via `nvidia-smi --query-gpu=index,uuid,memory.free,memory.total` (NVML — **no CUDA context created**).
- Pick the GPU with the most free VRAM (ties → lowest index).
- Pin `CUDA_VISIBLE_DEVICES=<uuid>` **before** torch/onnxruntime initialise, so the pipeline's default `cuda:0` / onnxruntime `device_id=0` transparently lands on the chosen card (verified: `pose_detector` uses `CUDAExecutionProvider` default device, VLM uses `device_map="auto"` → single visible GPU).
- Fail-fast (#43) preserved: if **no** GPU clears the budget (or none is visible), one `VRAM_PREFLIGHT_FAIL …` line + `exit(2)`.

No static per-GPU assignment — the container adapts to whatever's free, so a warm SGLang LLM (GPU 0) and CCTV inference (GPU 1) coexist on the `always_ai` host, and single-GPU boxes are unaffected.

## Tests

`vram_preflight_test.py` rewritten around the new `nvidia-smi` boundary: parse, select-freest, tie-break, pin-CUDA_VISIBLE_DEVICES, all-busy fail-fast (reports the freest candidate), no-GPU, nvidia-smi-unavailable, env-override relax. **108 gpu-service tests pass**, ruff clean. Callers (`rest_server`, `worker`) are unchanged — same `preflight_or_exit(classifier=, env_override=)` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)