### PR TITLE
fix(client-agent): re-attach RTSP creds for the snapshot poller

### DIFF
--- a/client-agent/client_agent/appliance.py
+++ b/client-agent/client_agent/appliance.py
@@ -108,6 +108,7 @@ def _camera_to_push_dict(cam: DiscoveredCamera) -> dict[str, Any]:
 
 def build_camera_registry(
     response: HeartbeatResponse,
+    environ: Mapping[str, str] | None = None,
 ) -> dict[str, CameraSnapshotSource]:
     """Project the heartbeat's camera config into the snapshot resolver
     registry (issue #44, refactored out of #41).
@@ -117,13 +118,22 @@ def build_camera_registry(
     the platform might send: top-level ``name``/``vendor``/``model`` and
     nested ``model_info.{manufacturer,model}`` (the appliance-pushed
     shape via :func:`_camera_to_push_dict`). Either way the panel gets a
-    label without a second platform round-trip."""
+    label without a second platform round-trip.
+
+    When ``environ`` is supplied, each RTSP url is re-credentialed from
+    ``cameras.env`` (the same resolver the buffer recorder uses): the platform
+    stores stream urls credential-free (#22), so a bare ``rtsp://host/path``
+    makes the snapshot poller's cv2/ffmpeg open 401 — leaving the /cameras
+    preview a placeholder. HTTP snapshot urls are left untouched (their auth is
+    the vendor endpoint's concern)."""
     out: dict[str, CameraSnapshotSource] = {}
     for cam in response.config.get("cameras", []):
         cam_id = cam.get("id")
         rtsp_url = cam.get("rtsp_url")
         if not cam_id or not rtsp_url:
             continue
+        if environ is not None:
+            rtsp_url = authenticated_rtsp_url(rtsp_url, environ)
         model_info = cam.get("model_info") or {}
         out[cam_id] = CameraSnapshotSource(
             rtsp_url=rtsp_url,
@@ -587,7 +597,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         heartbeat config. ``clear() + update()`` (not assignment) so the
         resolver closure keeps pointing at the same dict instance."""
         platform_camera_registry.clear()
-        platform_camera_registry.update(build_camera_registry(response))
+        platform_camera_registry.update(build_camera_registry(response, os.environ))
 
     if _is_platform_mode(os.environ):
         # Run one platform session up-front so a bad token / unreachable

--- a/client-agent/client_agent/appliance_test.py
+++ b/client-agent/client_agent/appliance_test.py
@@ -1492,6 +1492,46 @@ def test_build_camera_registry_extracts_name_vendor_model_from_heartbeat() -> No
     assert registry["cam-uuid-2"].model == "IPC-HFW"
 
 
+def test_build_camera_registry_injects_rtsp_credentials_from_environ() -> None:
+    """When ``environ`` is passed, the credential-free RTSP url the platform
+    stores (#22) is re-credentialed from ``cameras.env`` so the snapshot
+    poller's cv2/ffmpeg can authenticate — otherwise the /cameras preview stays
+    a placeholder. Already-credentialed urls are left untouched."""
+    from client_agent.appliance import build_camera_registry
+    from client_agent.platform import HeartbeatResponse
+
+    response = HeartbeatResponse(
+        config={
+            "cameras": [
+                {"id": "cam-1", "rtsp_url": "rtsp://192.168.88.89:554/live"},
+                {"id": "cam-2", "rtsp_url": "rtsp://u:p@192.168.88.90:554/live"},
+            ]
+        }
+    )
+    environ = {"RTSP_DEFAULT_USER": "admin", "RTSP_DEFAULT_PASS": "#J2Zxs9b0iMP"}
+
+    registry = build_camera_registry(response, environ)
+
+    # Bare url → creds injected; the '#'-leading password is percent-encoded.
+    assert registry["cam-1"].rtsp_url == "rtsp://admin:%23J2Zxs9b0iMP@192.168.88.89:554/live"
+    # Already-credentialed url is left as-is.
+    assert registry["cam-2"].rtsp_url == "rtsp://u:p@192.168.88.90:554/live"
+
+
+def test_build_camera_registry_without_environ_leaves_urls_bare() -> None:
+    """Backward-compat: no ``environ`` → urls stored verbatim."""
+    from client_agent.appliance import build_camera_registry
+    from client_agent.platform import HeartbeatResponse
+
+    response = HeartbeatResponse(
+        config={"cameras": [{"id": "cam-1", "rtsp_url": "rtsp://192.168.88.89:554/live"}]}
+    )
+
+    registry = build_camera_registry(response)
+
+    assert registry["cam-1"].rtsp_url == "rtsp://192.168.88.89:554/live"
+
+
 # ----- 5d. Buffer maintenance loop enforces BUFFER_HOURS (issue #51) -----
 
 

--- a/client-agent/client_agent/discovery.py
+++ b/client-agent/client_agent/discovery.py
@@ -18,6 +18,7 @@ on a physical camera in the operator's LAN (issue #21 acceptance #7).
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -262,6 +263,31 @@ def inject_credentials(url: str, credentials: tuple[str, str] | None) -> str:
     if parsed.port is not None:
         netloc = f"{userinfo}{parsed.hostname}:{parsed.port}"
     return parsed._replace(netloc=netloc).geturl()
+
+
+# ``scheme://user:pass@`` userinfo (RTSP camera creds) and SigV4 presigned-URL
+# query secrets (R2 PUT urls) — the two secret shapes that ride inside stream
+# and upload URLs. Bounded so the surrounding host/path/status stays intact.
+_URL_USERINFO_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/\s@]+@")
+_PRESIGNED_SECRET_RE = re.compile(
+    r"(?i)([?&](?:X-Amz-Signature|X-Amz-Credential|X-Amz-Security-Token|Signature|AWSAccessKeyId)=)[^&\s]+"
+)
+
+
+def scrub_url_credentials(text: str) -> str:
+    """Redact secrets from any URL embedded in a diagnostic string before it
+    crosses a trust boundary — e.g. the platform's snapshot/task error column,
+    which admins of *other* tenants may see (issue #53).
+
+    Strips ``scheme://user:pass@`` userinfo (RTSP camera creds — now live in
+    error messages because the snapshot/recorder paths inject them, #22) and
+    SigV4 presigned-URL query secrets (a leaked R2 PUT url is writable until it
+    expires). Everything else — host, path, status code, exception class — is
+    left intact so the operator's message stays diagnostic. Idempotent; safe on
+    strings with no URL. Keep the *local* log unscrubbed: journald is
+    operator-side and the operator owns these creds."""
+    text = _URL_USERINFO_RE.sub(r"\1", text)
+    return _PRESIGNED_SECRET_RE.sub(r"\1REDACTED", text)
 
 
 def guess_vendor_from_open_ports(open_ports: set[int]) -> str:

--- a/client-agent/client_agent/discovery_test.py
+++ b/client-agent/client_agent/discovery_test.py
@@ -1033,3 +1033,39 @@ def test_build_tuya_camera_emits_manual_url_row_with_product_key_as_model() -> N
     assert cam.needs_manual_url is True
     assert cam.discovery_method == "tuya-local"
     assert cam.snapshot_url is None
+
+
+def test_scrub_url_credentials_strips_rtsp_userinfo() -> None:
+    """Issue #53: RTSP camera creds embedded in an error string are removed
+    before the string can cross to the platform; host/path stay for triage."""
+    from client_agent.discovery import scrub_url_credentials
+
+    text = "cv2.VideoCapture failed to open 'rtsp://admin:s3cret@10.0.0.5:554/h264'"
+    scrubbed = scrub_url_credentials(text)
+
+    assert "s3cret" not in scrubbed
+    assert "admin:" not in scrubbed
+    assert "rtsp://10.0.0.5:554/h264" in scrubbed
+
+
+def test_scrub_url_credentials_redacts_presigned_sigv4_secrets() -> None:
+    """A leaked presigned R2 PUT url is writable until it expires — redact the
+    SigV4 query secrets from any transport-error message (issue #53 item 3)."""
+    from client_agent.discovery import scrub_url_credentials
+
+    text = (
+        "transport error: PUT https://acct.r2.cloudflarestorage.com/b/k"
+        "?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIAEXAMPLE%2F20260710 failed"
+    )
+    scrubbed = scrub_url_credentials(text)
+
+    assert "deadbeef" not in scrubbed
+    assert "AKIAEXAMPLE" not in scrubbed
+    assert "REDACTED" in scrubbed
+
+
+def test_scrub_url_credentials_is_noop_without_secrets() -> None:
+    from client_agent.discovery import scrub_url_credentials
+
+    text = "grab failed for camera cam-1: RuntimeError no frame"
+    assert scrub_url_credentials(text) == text

--- a/client-agent/client_agent/snapshot_poller.py
+++ b/client-agent/client_agent/snapshot_poller.py
@@ -31,6 +31,7 @@ from typing import Protocol
 
 import httpx
 
+from client_agent.discovery import scrub_url_credentials
 from client_agent.platform import SnapshotClaim
 from client_agent.snapshot import SnapshotGrabberFn
 from client_agent.web import CameraSnapshotSource
@@ -140,7 +141,13 @@ class SnapshotPoller:
             # platform might be displayed to admins of a different
             # tenant. Keep the platform-facing message scrubbed.
             logger.warning("snapshot grab failed for camera_id=%s: %s", claim.camera_id, exc)
-            self._report_failed(claim.request_id, f"grab failed: {exc}")
+            # Scrub before the message crosses to the platform's error column
+            # (issue #53): the grabber's exception embeds the url, which now
+            # carries injected RTSP userinfo. The local log above stays full.
+            self._report_failed(
+                claim.request_id,
+                scrub_url_credentials(f"grab failed for camera {claim.camera_id}: {exc}"),
+            )
             return True
 
         # 3. PUT to presigned URL. The URL carries its own SigV4
@@ -154,7 +161,9 @@ class SnapshotPoller:
                 claim.camera_id,
                 error,
             )
-            self._report_failed(claim.request_id, error)
+            # A transport-error PUT failure can embed the presigned R2 url
+            # (SigV4 query secrets) — scrub before it reaches the platform (#53).
+            self._report_failed(claim.request_id, scrub_url_credentials(error))
             return True
 
         # 4. Success — flip the row to uploaded so the next browser

--- a/client-agent/client_agent/snapshot_poller_test.py
+++ b/client-agent/client_agent/snapshot_poller_test.py
@@ -242,3 +242,66 @@ def test_run_once_reports_failed_does_not_propagate_grabber_exception() -> None:
     # Should NOT raise.
     handled = poller.run_once()
     assert handled is True
+
+
+def test_run_once_grab_failure_report_scrubs_credentials() -> None:
+    """Issue #53: the credentialed RTSP url the snapshot path now injects must
+    NOT reach the platform's error column (visible to other tenants' admins).
+    The grab-failure exception embeds the full url — report it scrubbed."""
+    platform = FakePlatform(next_claims=[_claim(camera_id="cam-9")])
+
+    def fake_grab(_url: str, _t: float) -> bytes:
+        raise RuntimeError(
+            "cv2.VideoCapture failed to open 'rtsp://admin:s3cret@10.0.0.5:554/h264'"
+        )
+
+    poller = SnapshotPoller(
+        platform=platform,
+        camera_resolver=lambda _id: CameraSnapshotSource(
+            rtsp_url="rtsp://admin:s3cret@10.0.0.5:554/h264"
+        ),
+        snapshot_grabber=fake_grab,
+        http_put=lambda _u, _b, _c: PutResult(success=True),
+    )
+
+    poller.run_once()
+
+    _req, status, error = platform.status_calls[0]
+    assert status == "failed"
+    assert error is not None
+    # No credentials leaked...
+    assert "s3cret" not in error
+    assert "admin:" not in error
+    # ...but still actionable: names the camera + the failing host.
+    assert "cam-9" in error
+    assert "10.0.0.5" in error
+
+
+def test_run_once_grab_failure_local_log_keeps_full_detail(caplog) -> None:
+    """Acceptance 2: the operator's own journald keeps the full url (creds
+    included) for diagnosis — only the platform-facing report is scrubbed."""
+    import logging
+
+    platform = FakePlatform(next_claims=[_claim(camera_id="cam-9")])
+
+    def fake_grab(_url: str, _t: float) -> bytes:
+        raise RuntimeError(
+            "cv2.VideoCapture failed to open 'rtsp://admin:s3cret@10.0.0.5:554/h264'"
+        )
+
+    poller = SnapshotPoller(
+        platform=platform,
+        camera_resolver=lambda _id: CameraSnapshotSource(
+            rtsp_url="rtsp://admin:s3cret@10.0.0.5:554/h264"
+        ),
+        snapshot_grabber=fake_grab,
+        http_put=lambda _u, _b, _c: PutResult(success=True),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        poller.run_once()
+
+    # Operator-side log keeps the creds; platform-facing report does not.
+    assert "s3cret" in caplog.text
+    _req, _status, error = platform.status_calls[0]
+    assert error is not None and "s3cret" not in error


### PR DESCRIPTION
## Bug (prod /cameras preview)

`https://exchange.antra.one/cameras` shows a placeholder instead of the ~30s-refreshed camera preview. Appliance log:

```
snapshot grab failed for camera_id=c3b6029e: cv2.VideoCapture failed to open 'rtsp://192.168.88.89:554/unicast/c1/s0/live'
```

Third instance of the #22 credential-strip bug (after the buffer recorder, #67). The platform stores stream urls credential-free; `build_camera_registry` stored that bare `rtsp://host/path` into the `CameraSnapshotSource` registry, and the snapshot poller (gpu-exchange #91) opened it with `cv2.VideoCapture` → 401 → no JPEG → the `/cameras` tile stays a placeholder.

## Fix

1. **Preview** — `build_camera_registry(response, environ=None)` re-credentials each RTSP url via `authenticated_rtsp_url` (the resolver the recorder already uses); `_refresh_camera_registry` passes `os.environ`. Both the snapshot poller **and** the on-site Flask snapshot route read this one registry, so both are fixed in one place. HTTP snapshot urls untouched; no-`environ` callers keep old behavior.

2. **Credential leak (Closes #53)** — injecting creds means a grab-failure exception now embeds live camera creds, and `snapshot_poller` reported `f"grab failed: {exc}"` straight to the platform's error column (visible to other tenants' admins). Added `discovery.scrub_url_credentials` (strips `scheme://user:pass@` userinfo + redacts SigV4 presigned query secrets) and applied it to both platform-facing reports; the local journald log stays full-detail. Verified `poller.py`'s `UploadResult.error` only carries status codes (no scrub needed).

## Tests

Preview: inject-from-environ (incl. `#`-password → `%23` + already-credentialed no-op) + backward-compat no-environ. Leak: `scrub_url_credentials` (userinfo / SigV4 / no-op) + poller reports-no-creds + local-log-keeps-detail. **259 client-agent tests pass**, ruff clean.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)