### PR TITLE
fix(client-agent): surface needs_manual_url cameras + skip link-local ONVIF xaddrs (#70)

### DIFF
--- a/client-agent/client_agent/appliance.py
+++ b/client-agent/client_agent/appliance.py
@@ -79,13 +79,19 @@ def _camera_to_push_dict(cam: DiscoveredCamera) -> dict[str, Any]:
     """Project a :class:`DiscoveredCamera` into the canonical
     ``POST /appliance/cameras`` payload (DD-09 gpu-exchange).
 
-    The wire shape is ``{rtsp_url, onvif_uuid?, name?, model_info?}``.
-    Vendor / model / discovery metadata land inside ``model_info`` as a
-    free-form jsonb so the platform can persist them without a schema
-    bump every time the discovery code learns a new field. Snapshot URL
-    is included there too — the operator's preview lives in the same
-    metadata blob."""
-    body: dict[str, Any] = {"rtsp_url": cam.rtsp_url}
+    The wire shape is ``{rtsp_url, needs_manual_url, name?, model_info?}``.
+    ``needs_manual_url`` is emitted as an explicit bool so the platform can
+    surface URL-less devices (Tuya #38 / Unknown-vendor #37, ``rtsp_url=""``)
+    on the /cameras page for the operator to fill in, instead of us dropping
+    them (#70). Vendor / model / discovery metadata land inside ``model_info``
+    as a free-form jsonb so the platform can persist them without a schema
+    bump every time the discovery code learns a new field. Snapshot URL is
+    included there too — the operator's preview lives in the same metadata
+    blob."""
+    body: dict[str, Any] = {
+        "rtsp_url": cam.rtsp_url,
+        "needs_manual_url": cam.needs_manual_url,
+    }
     name = f"{cam.vendor} {cam.model}".strip()
     if name:
         body["name"] = name
@@ -393,21 +399,19 @@ def run_platform_session(
     # Stage 2 Unknown-vendor (#37) and Stage 3 Tuya (#38) discovery can emit a
     # DiscoveredCamera with rtsp_url="" + needs_manual_url=True — the device
     # exists on the LAN but the streaming URI is per-device and only obtainable
-    # via the vendor app. The platform schema requires rtsp_url to be non-empty
-    # (z.string().min(1)) and rejects the whole batch on the first empty row,
-    # which previously caused every heartbeat cycle after a Tuya broadcast
-    # landed to fail with 400 Bad Request. Filter those rows out here; the
-    # devices stay in local discovery state and can surface in a future UI flow
-    # that lets the operator paste the manual URL.
-    skipped = [c for c in cameras if not c.rtsp_url]
-    if skipped:
+    # via the vendor app. The platform companion (#122) accepts these URL-less
+    # rows carrying needs_manual_url, so we push the whole discovered set and
+    # let the platform surface them on the operator's /cameras page (#70).
+    # (Before #122 the platform's z.string().min(1) rejected the whole batch on
+    # the first empty row — do not deploy this ahead of that companion.)
+    manual = [c for c in cameras if not c.rtsp_url]
+    if manual:
         logger.info(
-            "push_cameras: skipping %d camera(s) with empty rtsp_url (needs_manual_url): %s",
-            len(skipped),
-            ", ".join(f"{c.ip}:{c.port} ({c.vendor})" for c in skipped),
+            "push_cameras: surfacing %d needs_manual_url camera(s) to platform: %s",
+            len(manual),
+            ", ".join(f"{c.ip}:{c.port} ({c.vendor})" for c in manual),
         )
-    publishable = [c for c in cameras if c.rtsp_url]
-    payload = [_camera_to_push_dict(cam) for cam in publishable]
+    payload = [_camera_to_push_dict(cam) for cam in cameras]
     platform_client.push_cameras(payload)
 
     if active_recorders is None:

--- a/client-agent/client_agent/appliance_test.py
+++ b/client-agent/client_agent/appliance_test.py
@@ -330,6 +330,32 @@ def _make_camera(ip: str = "192.168.50.2") -> object:
     )
 
 
+def test_camera_to_push_dict_emits_needs_manual_url_flag() -> None:
+    """A URL-less camera (Tuya #38 / Unknown-vendor #37) must reach the
+    platform carrying ``needs_manual_url=True`` so the operator can paste the
+    per-device URI on the /cameras page — not be silently dropped (#70). A
+    normal URL-ful camera carries the flag as ``False`` so the platform has an
+    explicit signal either way."""
+    from client_agent.appliance import _camera_to_push_dict
+    from client_agent.discovery import DiscoveredCamera
+
+    manual = DiscoveredCamera(
+        ip="192.168.88.83",
+        port=554,
+        vendor="Unknown (nginx-RTSP / per-device URI)",
+        model="",
+        rtsp_url="",
+        discovery_method="rtsp-scan",
+        needs_manual_url=True,
+    )
+    manual_dict = _camera_to_push_dict(manual)
+    assert manual_dict["needs_manual_url"] is True
+    assert manual_dict["rtsp_url"] == ""
+
+    normal_dict = _camera_to_push_dict(_make_camera())
+    assert normal_dict["needs_manual_url"] is False
+
+
 def test_run_platform_session_registers_pushes_and_heartbeats() -> None:
     """Single iteration of the platform loop hits all three endpoints in
     the right order. ``run_platform_session`` is the testable unit; the
@@ -412,14 +438,14 @@ def test_run_platform_session_falls_back_to_rtsp_default_url_when_discovery_empt
     assert cameras[0]["rtsp_url"] == fallback_url
 
 
-def test_run_platform_session_filters_cameras_with_empty_rtsp_url() -> None:
+def test_run_platform_session_pushes_needs_manual_url_cameras_with_flag() -> None:
     """Stage 2 Unknown-vendor (#37) and Stage 3 Tuya (#38) discovery emit
     ``DiscoveredCamera(rtsp_url="", needs_manual_url=True)`` when the device
-    exists on the LAN but its streaming URI is per-device. The platform
-    validator rejects empty rtsp_url (``z.string().min(1)``) and 400s the
-    whole batch on the first invalid item, so heartbeat cycles after a Tuya
-    broadcast landed previously failed end-to-end. The appliance must filter
-    those rows out before the push and surface the count via the logger."""
+    exists on the LAN but its streaming URI is per-device. Once the platform
+    companion (#122) accepts URL-less rows, the appliance must push ALL
+    discovered cameras — the URL-less ones carrying ``needs_manual_url=True``
+    + ``rtsp_url=""`` — so they surface on the operator's /cameras page instead
+    of being silently dropped (#70). The mixed batch must still push cleanly."""
     import json as _json
 
     import httpx
@@ -472,10 +498,14 @@ def test_run_platform_session_filters_cameras_with_empty_rtsp_url() -> None:
 
     body = _json.loads(push_route.calls.last.request.read())
     cameras = body["cameras"]
-    assert len(cameras) == 1
-    assert cameras[0]["rtsp_url"] == real_cam.rtsp_url
-    # Belt-and-braces: no row in the payload should ever have empty rtsp_url.
-    assert all(c["rtsp_url"] for c in cameras)
+    # All three rows reach the platform — nothing is filtered out.
+    assert len(cameras) == 3
+    by_url = {c["rtsp_url"]: c for c in cameras}
+    assert by_url[real_cam.rtsp_url]["needs_manual_url"] is False
+    # Both URL-less devices survive, flagged for the operator to fill in.
+    url_less = [c for c in cameras if not c["rtsp_url"]]
+    assert len(url_less) == 2
+    assert all(c["needs_manual_url"] is True for c in url_less)
 
 
 def test_run_platform_session_starts_recorder_for_each_enabled_camera() -> None:

--- a/client-agent/client_agent/discovery.py
+++ b/client-agent/client_agent/discovery.py
@@ -349,13 +349,35 @@ def quiet_wsdiscovery_loggers() -> None:
         logging.getLogger(name).setLevel(logging.ERROR)
 
 
+def _is_link_local_xaddr(xaddr: str) -> bool:
+    """True when the ONVIF service address points at a link-local host.
+
+    IPv6 link-local (``fe80::/10``) devices advertise an xaddr the appliance
+    can't reach without a scope id, and the unbracketed ``fe80::…`` spelling
+    some cameras emit even makes ``urlparse(...).port`` raise ``ValueError``.
+    IPv4 link-local (``169.254/16``, APIPA) is likewise off the normal LAN.
+    Either way enrich fails on every discovery cycle, spamming the log (#70),
+    so we detect these on the raw authority and drop them at probe time.
+
+    Matches on the raw ``fe80:`` / ``169.254.`` prefix rather than
+    ``ipaddress`` parsing so the unbracketed IPv6 form — which ``ipaddress``
+    and ``urlparse`` both choke on — is still caught."""
+    authority = xaddr.split("://", 1)[-1].split("/", 1)[0]
+    host = authority.strip()
+    if host.startswith("["):  # bracketed IPv6: [fe80::1%eth0]:5357
+        host = host[1:].split("]", 1)[0]
+    host = host.split("%", 1)[0].lower()
+    return host.startswith("fe80:") or host.startswith("169.254.")
+
+
 def _real_probe(timeout: float) -> list[ProbeMatch]:
     """WS-Discovery probe via the ``wsdiscovery`` package.
 
     Sends a multicast Probe to ``239.255.255.250:3702`` and collects every
     ProbeMatch reply within ``timeout`` seconds. Each device may publish
-    multiple ``XAddrs``; we take the first because it's the one the device
-    advertised first and that's typically the device-service URL.
+    multiple ``XAddrs``; we take the first *routable* one (skipping link-local
+    fe80::/169.254 candidates enrich can't reach, #70), which is typically the
+    device-service URL.
 
     No unit test exercises this — it's covered only by the manual test on
     a real camera (issue #21 #7). If the import fails (deps not installed
@@ -384,9 +406,14 @@ def _real_probe(timeout: float) -> list[ProbeMatch]:
     seen: set[str] = set()
     for svc in services:
         xaddrs = list(svc.getXAddrs() or [])
-        if not xaddrs:
+        # Prefer a routable address; drop link-local (fe80::/169.254) candidates
+        # that enrich can't reach and whose unbracketed IPv6 form even crashes
+        # urlparse(...).port (#70). A device advertising only link-local xaddrs
+        # is skipped entirely.
+        routable = [x for x in xaddrs if not _is_link_local_xaddr(x)]
+        if not routable:
             continue
-        xaddr = xaddrs[0]
+        xaddr = routable[0]
         if xaddr in seen:
             continue
         seen.add(xaddr)

--- a/client-agent/client_agent/discovery_test.py
+++ b/client-agent/client_agent/discovery_test.py
@@ -1103,6 +1103,70 @@ def test_quiet_wsdiscovery_loggers_suppresses_resolve_handler_warning(caplog) ->
     assert not any("_handle_resolve" in r.getMessage() for r in caplog.records)
 
 
+def test_is_link_local_xaddr_detects_ipv6_and_ipv4_link_local() -> None:
+    """ONVIF WS-Discovery can advertise a device on its IPv6 link-local
+    (fe80::/10) or IPv4 APIPA (169.254/16) address. Those aren't reachable
+    without a scope id, and the unbracketed ``fe80::…`` form even makes
+    ``urlparse(...).port`` raise — so enrich errors every discovery cycle
+    (#70). The predicate flags them across the bracketed, unbracketed, and
+    zone-id spellings while leaving ordinary private-LAN addresses alone."""
+    from client_agent.discovery import _is_link_local_xaddr
+
+    assert _is_link_local_xaddr("http://fe80::1234:5357/onvif/device_service") is True
+    assert _is_link_local_xaddr("http://[fe80::1234]:5357/onvif/device_service") is True
+    assert _is_link_local_xaddr("http://[fe80::1234%25eth0]:5357/onvif/device_service") is True
+    assert _is_link_local_xaddr("http://169.254.10.20:5357/onvif/device_service") is True
+
+    assert _is_link_local_xaddr("http://192.168.88.83:5357/onvif/device_service") is False
+    assert _is_link_local_xaddr("http://10.0.0.5/onvif/device_service") is False
+
+
+def test_real_probe_skips_link_local_and_prefers_routable_xaddr(monkeypatch) -> None:
+    """A camera advertising only a link-local xaddr must never become a
+    ProbeMatch — enrich can't reach it and would error every cycle, and the
+    unbracketed ``fe80::…`` form would even crash the probe on ``.port`` (#70).
+    A camera advertising both a link-local and a routable address is kept via
+    its routable one. The WS-Discovery library is faked so no multicast fires."""
+    import sys
+    import types
+
+    from client_agent import discovery
+
+    class _FakeService:
+        def __init__(self, xaddrs: list[str]) -> None:
+            self._xaddrs = xaddrs
+
+        def getXAddrs(self) -> list[str]:
+            return self._xaddrs
+
+    class _FakeWSD:
+        def start(self) -> None: ...
+
+        def searchServices(self, timeout: int) -> list:
+            return [
+                # Link-local only (unbracketed) — would crash urlparse().port.
+                _FakeService(["http://fe80::abcd:5357/onvif/device_service"]),
+                # Link-local first, routable second — keep the routable one.
+                _FakeService(
+                    [
+                        "http://[fe80::ef01]:5357/onvif/device_service",
+                        "http://192.168.88.50:80/onvif/device_service",
+                    ]
+                ),
+            ]
+
+        def stop(self) -> None: ...
+
+    fake_module = types.ModuleType("wsdiscovery.discovery")
+    fake_module.ThreadedWSDiscovery = lambda: _FakeWSD()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "wsdiscovery.discovery", fake_module)
+
+    matches = discovery._real_probe(timeout=1.0)
+
+    assert [m.ip for m in matches] == ["192.168.88.50"]
+    assert matches[0].port == 80
+
+
 def test_real_probe_silences_wsdiscovery_daemon_noise(monkeypatch, caplog) -> None:
     """``_real_probe`` is the only place we start the WS-Discovery daemon
     thread, so it must silence the library's ``_handle_resolve`` noise as part


### PR DESCRIPTION
Closes #70. Companion (platform half): KopalnieKrypto/gpu-exchange#122 — **already landed on staging + production**, so this is safe to merge/deploy.

## Problem
The cameraboy appliance found ~7 cameras on the LAN but only 1 reached `exchange.antra.one/cameras`: every URL-less camera (Tuya #38 / Unknown-vendor #37 — `rtsp_url=""` + `needs_manual_url=True`) was filtered out before the platform push, a workaround for the platform's `z.string().min(1)` rejecting empty `rtsp_url`. Separately, IPv6 link-local ONVIF xaddrs (`fe80::…`) made enrich error on every discovery cycle (~413 lines/cycle in prod).

## Change
- `_camera_to_push_dict` emits `needs_manual_url` as an explicit bool (`rtsp_url` stays `""` for URL-less devices).
- `run_platform_session` no longer filters URL-less rows — it surfaces the count via the logger and pushes the whole discovered set (companion #122 now accepts these rows).
- New `_is_link_local_xaddr` predicate; `_real_probe` picks the first *routable* XAddr and drops link-local (`fe80::/10`, `169.254/16`) candidates before they reach enrich. Also fixes a latent crash where the unbracketed `fe80::…` form made `urlparse(...).port` raise `ValueError`.

## Tests (TDD, red→green)
- `appliance_test.py::test_camera_to_push_dict_emits_needs_manual_url_flag`
- `appliance_test.py::test_run_platform_session_pushes_needs_manual_url_cameras_with_flag` (rewritten from the old `..._filters_...` test)
- `discovery_test.py::test_is_link_local_xaddr_detects_ipv6_and_ipv4_link_local`
- `discovery_test.py::test_real_probe_skips_link_local_and_prefers_routable_xaddr`

Full client-agent suite: **272 passed**, ruff clean.

## Verified on prod hardware (`cctv-vps-camera`, cameraboy-production)
Deployed this branch, restarted the appliance, watched two clean cycles:
- ✅ `push_cameras: surfacing 6 needs_manual_url camera(s)` — 192.168.88.83–88
- ✅ `POST /appliance/cameras → 204 No Content` on the mixed batch (previously 400)
- ✅ 0 `fe80` link-local enrich errors (was ~413/cycle)
- ✅ 0 tracebacks; register/push/heartbeat all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)