### PR TITLE
fix(gpu-service): set Content-Type application/json on presigned result PUT

### DIFF
--- a/gpu-service/gpu_service/http_client.py
+++ b/gpu-service/gpu_service/http_client.py
@@ -63,7 +63,12 @@ class PresignedHttpClient:
 
     def upload(self, url: str, body: bytes) -> None:
         def _op() -> None:
-            request = urllib.request.Request(url, data=body, method="PUT")
+            request = urllib.request.Request(
+                url,
+                data=body,
+                method="PUT",
+                headers={"Content-Type": "application/json"},
+            )
             with self._opener(request) as response:
                 # Drain the body so the connection can be reused / closed
                 # cleanly on R2's side.

--- a/gpu-service/gpu_service/http_client_test.py
+++ b/gpu-service/gpu_service/http_client_test.py
@@ -87,6 +87,7 @@ class TestPresignedHttpClientUpload:
             captured["url"] = request.full_url
             captured["data"] = request.data
             captured["method"] = request.get_method()
+            captured["content_type"] = request.get_header("Content-type")
             return _FakeResponse(b"", status=200)
 
         client = PresignedHttpClient(opener=opener, sleep=_no_sleep)
@@ -96,6 +97,7 @@ class TestPresignedHttpClientUpload:
         assert captured["url"] == "https://r2.example.com/put/report.html"
         assert captured["data"] == b"<html>ok</html>"
         assert captured["method"] == "PUT"
+        assert captured["content_type"] == "application/json"
 
     def test_raises_on_non_2xx_response(self) -> None:
         opener = MagicMock(return_value=_FakeResponse(b"forbidden", status=403))


### PR DESCRIPTION
## Summary
Fixes #75.

- Set `Content-Type: application/json` on `PresignedHttpClient.upload()` PUT requests so R2 stores correct metadata for `result.json` in REST/gpu-agent mode.
- Extended the existing upload test to assert the header is present.

## Test plan
- [x] `uv run pytest gpu-service/gpu_service/http_client_test.py -v` — all 6 tests pass

Made with [Cursor](https://cursor.com)